### PR TITLE
ci: populate CHANGELOG with commit messages during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,30 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           DATE=$(date +%Y-%m-%d)
-          perl -pi -e "s/## \[Unreleased\]/## [Unreleased]\n\n## [${VERSION}] - ${DATE}/" CHANGELOG.md
+
+          # Collect commits since last tag
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+          if [ -n "$LATEST_TAG" ]; then
+            COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"- %s" --no-merges | grep -v "^- chore: release ")
+          else
+            COMMITS=$(git log --pretty=format:"- %s" --no-merges | grep -v "^- chore: release ")
+          fi
+
+          # Build new changelog via awk to avoid special-char issues
+          awk -v ver="$VERSION" -v date="$DATE" -v commits="$COMMITS" '
+            /^## \[Unreleased\]/ {
+              print "## [Unreleased]"
+              print ""
+              print "## [" ver "] - " date
+              if (commits != "") {
+                print ""
+                n = split(commits, lines, "\n")
+                for (i = 1; i <= n; i++) print lines[i]
+              }
+              next
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
 
       - name: Commit version bump
         run: |


### PR DESCRIPTION
## Summary

The release workflow was only inserting empty version headers into CHANGELOG.md (e.g. `## [0.3.1] - 2026-03-18` with no content below). This fix collects commits since the last tag and writes them as bullet points under the new version section.

## Changes

- Collect commits since last tag via `git log --no-merges`, excluding `chore: release` commits
- Use `awk` to insert the version header and commit list into CHANGELOG.md (safe against special characters in commit messages, unlike the previous `perl` one-liner)

## Expected output

```markdown
## [Unreleased]

## [0.4.0] - 2026-03-19

- feat: in-app update via Homebrew with progress UI (#11)
- ci: add SwiftLint and SwiftFormat checks (#9)
- Fix plugin updates and add hot-reload (#8)
```