### PR TITLE
fix: prevent duplicate app instances on login

### DIFF
--- a/Sources/StatusBar/App/main.swift
+++ b/Sources/StatusBar/App/main.swift
@@ -1,5 +1,28 @@
 import AppKit
 
+// Single-instance guard: exit if another StatusBar is already running
+let myPID = ProcessInfo.processInfo.processIdentifier
+let isDuplicate: Bool = {
+    // Check by bundle identifier (installed .app)
+    if let bid = Bundle.main.bundleIdentifier {
+        let others = NSRunningApplication.runningApplications(withBundleIdentifier: bid)
+        if others.contains(where: { $0.processIdentifier != myPID && !$0.isTerminated }) {
+            return true
+        }
+    }
+    // Check by executable name (development builds without bundle ID)
+    let myName = ProcessInfo.processInfo.processName
+    return NSWorkspace.shared.runningApplications.contains {
+        $0.processIdentifier != myPID
+            && !$0.isTerminated
+            && $0.executableURL?.lastPathComponent == myName
+    }
+}()
+
+if isDuplicate {
+    exit(0)
+}
+
 let app = NSApplication.shared
 let delegate = AppDelegate()
 app.delegate = delegate

--- a/Sources/StatusBar/Preferences/Sections/BehaviorSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/BehaviorSection.swift
@@ -53,6 +53,11 @@ struct BehaviorSection: View {
 
 enum LaunchAtLoginService {
     static func setEnabled(_ enabled: Bool) {
+        // Only register with SMAppService when running as a proper .app bundle.
+        // Development builds (.build/debug/StatusBar) should not register as login items.
+        guard Bundle.main.bundleURL.pathExtension == "app" else {
+            return
+        }
         do {
             if enabled {
                 try SMAppService.mainApp.register()
@@ -60,7 +65,7 @@ enum LaunchAtLoginService {
                 try SMAppService.mainApp.unregister()
             }
         } catch {
-            // SPM executables without a proper bundle may fail silently
+            // SMAppService may fail for unsigned or ad-hoc signed bundles
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes an issue where multiple StatusBar instances launch simultaneously after a system restart when "Launch at Login" is enabled — particularly in development environments where `swift build` produces a raw executable.

## Changes
- **Single-instance guard** (`main.swift`): On startup, check if another StatusBar process is already running (by bundle identifier or executable name) and exit immediately if so
- **Skip login item registration in dev builds** (`BehaviorSection.swift`): `SMAppService.mainApp.register()` is now only called when running from a `.app` bundle, preventing `.build/debug/StatusBar` from being registered as a login item

## Notes
- If a stale login item from a previous dev build still exists, it can be removed manually via **System Settings > General > Login Items**
- The single-instance check covers both installed `.app` bundles (via `bundleIdentifier`) and raw executables (via process name), so it works in all environments