### PR TITLE
feat: hide status bar when fullscreen app is active

### DIFF
--- a/Sources/StatusBar/App/StatusBarController.swift
+++ b/Sources/StatusBar/App/StatusBarController.swift
@@ -11,6 +11,9 @@ final class StatusBarController {
     private var dwellTimer: Timer?
     private var isBarHidden = false
     private var rebuildTask: Task<Void, Never>?
+    private var spaceObserver: NSObjectProtocol?
+    private var appActivationObserver: NSObjectProtocol?
+    private var fullscreenHiddenIndices: Set<Int> = []
 
     func setup() {
         createBarWindows()
@@ -30,11 +33,13 @@ final class StatusBarController {
         observeShadowPreferences()
         observeTintPreferences()
         observeBehaviorPreferences()
+        observeFullscreenPreference()
     }
 
     private func createBarWindows() {
         barWindows.forEach { $0.orderOut(nil) }
         barWindows.removeAll()
+        fullscreenHiddenIndices.removeAll()
 
         for (index, screen) in NSScreen.screens.enumerated() {
             let window = BarWindow(screen: screen)
@@ -43,6 +48,8 @@ final class StatusBarController {
             window.orderFrontRegardless()
             barWindows.append(window)
         }
+
+        updateFullscreenVisibility()
     }
 
     private func handleScreenChange() {
@@ -182,6 +189,106 @@ final class StatusBarController {
         }
     }
 
+    // MARK: - Fullscreen Detection
+
+    private func observeFullscreenPreference() {
+        withObservationTracking {
+            _ = PreferencesModel.shared.hideInFullscreen
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.applyFullscreenState()
+                self?.observeFullscreenPreference()
+            }
+        }
+        applyFullscreenState()
+    }
+
+    private func applyFullscreenState() {
+        let enabled = PreferencesModel.shared.hideInFullscreen
+        if enabled, spaceObserver == nil {
+            installFullscreenObservers()
+            updateFullscreenVisibility()
+        } else if !enabled {
+            removeFullscreenObservers()
+            restoreFullscreenHiddenWindows()
+        }
+    }
+
+    private func installFullscreenObservers() {
+        removeFullscreenObservers()
+        let nc = NSWorkspace.shared.notificationCenter
+        spaceObserver = nc.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateFullscreenVisibility()
+            }
+        }
+        appActivationObserver = nc.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateFullscreenVisibility()
+            }
+        }
+    }
+
+    private func removeFullscreenObservers() {
+        if let observer = spaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            spaceObserver = nil
+        }
+        if let observer = appActivationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            appActivationObserver = nil
+        }
+    }
+
+    private func restoreFullscreenHiddenWindows() {
+        for index in fullscreenHiddenIndices {
+            guard index < barWindows.count else {
+                continue
+            }
+            showBarWindow(barWindows[index])
+        }
+        fullscreenHiddenIndices.removeAll()
+    }
+
+    private func updateFullscreenVisibility() {
+        guard PreferencesModel.shared.hideInFullscreen else {
+            return
+        }
+
+        let screens = NSScreen.screens
+        let fullscreenIndices = FullscreenDetector.fullscreenScreenIndices(for: screens)
+
+        for index in screens.indices {
+            guard index < barWindows.count else {
+                continue
+            }
+            let window = barWindows[index]
+
+            if fullscreenIndices.contains(index) {
+                if window.isVisible {
+                    window.orderOut(nil)
+                    fullscreenHiddenIndices.insert(index)
+                }
+            } else if fullscreenHiddenIndices.contains(index) {
+                fullscreenHiddenIndices.remove(index)
+                showBarWindow(window)
+            }
+        }
+    }
+
+    private func showBarWindow(_ window: BarWindow) {
+        window.orderFrontRegardless()
+        window.alphaValue = isBarHidden ? 0 : 1
+    }
+
     private func fadeBarWindows(hide: Bool) {
         let duration = PreferencesModel.shared.autoHideFadeDuration
         NSAnimationContext.runAnimationGroup { context in
@@ -205,6 +312,8 @@ final class StatusBarController {
         }
         dwellTimer?.invalidate()
         dwellTimer = nil
+        removeFullscreenObservers()
+        fullscreenHiddenIndices.removeAll()
         registry.stopAll()
         barWindows.forEach { $0.orderOut(nil) }
         barWindows.removeAll()

--- a/Sources/StatusBar/Config/StatusBarConfig.swift
+++ b/Sources/StatusBar/Config/StatusBarConfig.swift
@@ -256,6 +256,7 @@ struct BehaviorConfig: Codable {
     var autoHideDwellTime: Double
     var autoHideFadeDuration: Double
     var launchAtLogin: Bool
+    var hideInFullscreen: Bool
 
     init() {
         let d = PreferencesModel.Defaults.self
@@ -263,6 +264,7 @@ struct BehaviorConfig: Codable {
         autoHideDwellTime = d.autoHideDwellTime
         autoHideFadeDuration = d.autoHideFadeDuration
         launchAtLogin = d.launchAtLogin
+        hideInFullscreen = d.hideInFullscreen
     }
 
     @MainActor
@@ -271,6 +273,7 @@ struct BehaviorConfig: Codable {
         autoHideDwellTime = p.autoHideDwellTime
         autoHideFadeDuration = p.autoHideFadeDuration
         launchAtLogin = p.launchAtLogin
+        hideInFullscreen = p.hideInFullscreen
     }
 
     @MainActor
@@ -279,6 +282,7 @@ struct BehaviorConfig: Codable {
         p.autoHideDwellTime = autoHideDwellTime
         p.autoHideFadeDuration = autoHideFadeDuration
         p.launchAtLogin = launchAtLogin
+        p.hideInFullscreen = hideInFullscreen
     }
 }
 

--- a/Sources/StatusBar/Preferences/PreferencesModel.swift
+++ b/Sources/StatusBar/Preferences/PreferencesModel.swift
@@ -182,6 +182,10 @@ final class PreferencesModel: ThemeProvider {
         didSet { scheduleFlush(); bump() }
     }
 
+    var hideInFullscreen: Bool {
+        didSet { scheduleFlush(); bump() }
+    }
+
     // MARK: - Notifications
 
     var notifyBatteryLow: Bool {
@@ -330,6 +334,7 @@ final class PreferencesModel: ThemeProvider {
         autoHideDwellTime = d.autoHideDwellTime
         autoHideFadeDuration = d.autoHideFadeDuration
         launchAtLogin = d.launchAtLogin
+        hideInFullscreen = d.hideInFullscreen
 
         notifyBatteryLow = d.notifyBatteryLow
         batteryThreshold = d.batteryThreshold
@@ -403,6 +408,7 @@ final class PreferencesModel: ThemeProvider {
             autoHideDwellTime = d.autoHideDwellTime
             autoHideFadeDuration = d.autoHideFadeDuration
             launchAtLogin = d.launchAtLogin
+            hideInFullscreen = d.hideInFullscreen
         }
     }
 
@@ -581,6 +587,7 @@ extension PreferencesModel {
         static let autoHideDwellTime: Double = 0.3
         static let autoHideFadeDuration: Double = 0.2
         static let launchAtLogin: Bool = false
+        static let hideInFullscreen: Bool = true
 
         // Notifications
         static let notifyBatteryLow: Bool = false

--- a/Sources/StatusBar/Preferences/Sections/BehaviorSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/BehaviorSection.swift
@@ -35,6 +35,13 @@ struct BehaviorSection: View {
                 .padding(8)
             }
 
+            GroupBox("Fullscreen") {
+                VStack(spacing: 10) {
+                    ToggleRow(label: "Hide in Fullscreen", value: $model.hideInFullscreen)
+                }
+                .padding(8)
+            }
+
             GroupBox("Launch") {
                 VStack(spacing: 10) {
                     ToggleRow(label: "Launch at Login", value: $model.launchAtLogin)

--- a/Sources/StatusBar/Services/FullscreenDetector.swift
+++ b/Sources/StatusBar/Services/FullscreenDetector.swift
@@ -1,0 +1,57 @@
+import AppKit
+
+/// Checks which screens currently have a native fullscreen window.
+/// Fetches the window list once and checks all screens in a single pass.
+enum FullscreenDetector {
+    static func fullscreenScreenIndices(for screens: [NSScreen]) -> Set<Int> {
+        guard !screens.isEmpty,
+              let windowInfoList = CGWindowListCopyWindowInfo(
+                  [.optionOnScreenOnly, .excludeDesktopElements],
+                  kCGNullWindowID
+              ) as? [[String: Any]]
+        else {
+            return []
+        }
+
+        let myPID = ProcessInfo.processInfo.processIdentifier
+        let mainScreenHeight = screens.first?.frame.height ?? 0
+
+        // Pre-compute CG-coordinate Y origins for each screen
+        let screenCGYs = screens.map { mainScreenHeight - $0.frame.maxY }
+
+        var result = Set<Int>()
+
+        for info in windowInfoList {
+            guard let layer = info[kCGWindowLayer as String] as? Int,
+                  layer == 0,
+                  let pid = info[kCGWindowOwnerPID as String] as? pid_t,
+                  pid != myPID,
+                  let boundsDict = info[kCGWindowBounds as String] as? NSDictionary
+            else {
+                continue
+            }
+
+            var windowRect = CGRect.zero
+            guard CGRectMakeWithDictionaryRepresentation(boundsDict as CFDictionary, &windowRect)
+            else {
+                continue
+            }
+
+            for (index, screen) in screens.enumerated() where !result.contains(index) {
+                if abs(windowRect.width - screen.frame.width) < 2,
+                   abs(windowRect.height - screen.frame.height) < 2,
+                   abs(windowRect.origin.x - screen.frame.origin.x) < 2,
+                   abs(windowRect.origin.y - screenCGYs[index]) < 2
+                {
+                    result.insert(index)
+                }
+            }
+
+            // Early exit if all screens matched
+            if result.count == screens.count {
+                break
+            }
+        }
+        return result
+    }
+}

--- a/Tests/StatusBarTests/ConfigRoundTripTests.swift
+++ b/Tests/StatusBarTests/ConfigRoundTripTests.swift
@@ -24,6 +24,7 @@ struct ConfigRoundTripTests {
         #expect(decoded.global.typography.iconFontSize == original.global.typography.iconFontSize)
         #expect(decoded.global.graphs.dataPoints == original.global.graphs.dataPoints)
         #expect(decoded.global.behavior.autoHide == original.global.behavior.autoHide)
+        #expect(decoded.global.behavior.hideInFullscreen == original.global.behavior.hideInFullscreen)
         #expect(decoded.global.notifications.batteryLow == original.global.notifications.batteryLow)
     }
 
@@ -80,6 +81,25 @@ struct ConfigRoundTripTests {
         #expect(decoded.cpuHigh == true)
         #expect(decoded.cpuThreshold == 90.0)
         #expect(decoded.cpuSustainedDuration == 30.0)
+    }
+
+    @Test("BehaviorConfig preserves all fields through YAML")
+    func behaviorConfigRoundTrip() throws {
+        var behavior = BehaviorConfig()
+        behavior.autoHide = true
+        behavior.autoHideDwellTime = 0.5
+        behavior.autoHideFadeDuration = 0.3
+        behavior.launchAtLogin = true
+        behavior.hideInFullscreen = false
+
+        let yaml = try YAMLEncoder().encode(behavior)
+        let decoded = try YAMLDecoder().decode(BehaviorConfig.self, from: yaml)
+
+        #expect(decoded.autoHide == true)
+        #expect(decoded.autoHideDwellTime == 0.5)
+        #expect(decoded.autoHideFadeDuration == 0.3)
+        #expect(decoded.launchAtLogin == true)
+        #expect(decoded.hideInFullscreen == false)
     }
 
     @Test("Empty widget list round-trips correctly")


### PR DESCRIPTION
## Summary
Hide the status bar on screens that have a native fullscreen app (e.g., YouTube in Safari, full-screen terminal). Enabled by default via a new "Hide in Fullscreen" toggle in Preferences > Behavior.

## Changes
- **FullscreenDetector** (`Services/FullscreenDetector.swift`): New utility that fetches the window list once via `CGWindowListCopyWindowInfo` and checks all screens in a single pass for fullscreen windows (layer 0, bounds matching screen frame)
- **StatusBarController**: Observes `activeSpaceDidChangeNotification` and `didActivateApplicationNotification` to trigger fullscreen checks. Per-screen `orderOut`/`orderFrontRegardless` for instant hide/show, respecting auto-hide alpha state on restore
- **PreferencesModel**: `hideInFullscreen` property (default: `true`)
- **BehaviorSection**: "Hide in Fullscreen" toggle in Preferences UI
- **BehaviorConfig**: YAML config persistence for the new setting
- **ConfigRoundTripTests**: Round-trip test for `BehaviorConfig` including `hideInFullscreen`

## Notes
- Detection uses CG coordinate conversion (top-left origin) to match window bounds against NSScreen frames on multi-monitor setups
- `fullscreenHiddenIndices` is cleared inside `createBarWindows()` to prevent stale indices when windows are rebuilt (e.g., dimension slider drag)
- Fullscreen hide uses `orderOut`/`orderFront` (not alpha animation) so it doesn't conflict with the auto-hide fade mechanism