### PR TITLE
feat: add Developer Mode toggle to gate plugin development UI

### DIFF
--- a/Sources/StatusBar/Config/StatusBarConfig.swift
+++ b/Sources/StatusBar/Config/StatusBarConfig.swift
@@ -34,6 +34,7 @@ struct GlobalConfig: Codable {
     var graphs: GraphsConfig
     var behavior: BehaviorConfig
     var notifications: NotificationsConfig
+    var devMode: Bool?
 
     init() {
         bar = BarConfig()
@@ -42,6 +43,7 @@ struct GlobalConfig: Codable {
         graphs = GraphsConfig()
         behavior = BehaviorConfig()
         notifications = NotificationsConfig()
+        devMode = nil
     }
 
     @MainActor
@@ -52,6 +54,7 @@ struct GlobalConfig: Codable {
         graphs = GraphsConfig(from: prefs)
         behavior = BehaviorConfig(from: prefs)
         notifications = NotificationsConfig(from: prefs)
+        devMode = prefs.devModeEnabled ? true : nil
     }
 
     @MainActor
@@ -62,6 +65,7 @@ struct GlobalConfig: Codable {
         graphs.apply(to: prefs)
         behavior.apply(to: prefs)
         notifications.apply(to: prefs)
+        prefs.devModeEnabled = devMode ?? PreferencesModel.Defaults.devModeEnabled
     }
 }
 

--- a/Sources/StatusBar/Preferences/PreferencesModel.swift
+++ b/Sources/StatusBar/Preferences/PreferencesModel.swift
@@ -220,6 +220,12 @@ final class PreferencesModel: ThemeProvider {
         didSet { scheduleFlush(); bump() }
     }
 
+    // MARK: - Developer
+
+    var devModeEnabled: Bool {
+        didSet { scheduleFlush(); bump() }
+    }
+
     // MARK: - Computed Colors
 
     var accentColor: Color {
@@ -344,6 +350,8 @@ final class PreferencesModel: ThemeProvider {
         notifyMemoryHigh = d.notifyMemoryHigh
         memoryThreshold = d.memoryThreshold
         memorySustainedDuration = d.memorySustainedDuration
+
+        devModeEnabled = d.devModeEnabled
     }
 
     // MARK: - Reset
@@ -434,6 +442,7 @@ final class PreferencesModel: ThemeProvider {
             resetGraphs()
             resetBehavior()
             resetNotifications()
+            devModeEnabled = Defaults.devModeEnabled
         }
     }
 
@@ -598,6 +607,9 @@ extension PreferencesModel {
         static let notifyMemoryHigh: Bool = false
         static let memoryThreshold: Double = 90.0
         static let memorySustainedDuration: Double = 5.0
+
+        /// Developer
+        static let devModeEnabled: Bool = false
     }
 }
 

--- a/Sources/StatusBar/Preferences/Sections/AboutSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/AboutSection.swift
@@ -88,6 +88,29 @@ struct AboutSection: View {
                 .padding(8)
             }
 
+            GroupBox("Developer") {
+                VStack(spacing: 10) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Developer Mode")
+                                .font(.system(size: 13, weight: .medium))
+                            Text("Shows plugin development tools in the Plugins section.")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Toggle("", isOn: Binding(
+                            get: { PreferencesModel.shared.devModeEnabled },
+                            set: { PreferencesModel.shared.devModeEnabled = $0 }
+                        ))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                    }
+                }
+                .padding(8)
+            }
+
             GroupBox("Reset") {
                 VStack(spacing: 10) {
                     HStack {

--- a/Sources/StatusBar/Preferences/Sections/PluginsSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/PluginsSection.swift
@@ -110,58 +110,60 @@ struct PluginsSection: View {
                 .padding(.vertical, 4)
             }
 
-            // Development
-            GroupBox("Development") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        TextField("Path to .statusplugin bundle", text: $devPath)
-                            .textFieldStyle(.roundedBorder)
+            // Development (visible only in Dev Mode)
+            if PreferencesModel.shared.devModeEnabled {
+                GroupBox("Development") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack {
+                            TextField("Path to .statusplugin bundle", text: $devPath)
+                                .textFieldStyle(.roundedBorder)
 
-                        Button("Browse...") {
-                            browseForPlugin()
+                            Button("Browse...") {
+                                browseForPlugin()
+                            }
+
+                            Button("Load") {
+                                loadDevPlugin()
+                            }
+                            .disabled(devPath.isEmpty)
                         }
 
-                        Button("Load") {
-                            loadDevPlugin()
+                        if let devError {
+                            Label(devError, systemImage: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.red)
+                                .font(.caption)
                         }
-                        .disabled(devPath.isEmpty)
-                    }
 
-                    if let devError {
-                        Label(devError, systemImage: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.red)
-                            .font(.caption)
-                    }
-
-                    if !devPlugins.isEmpty {
-                        VStack(spacing: 0) {
-                            ForEach(devPlugins, id: \.id) { plugin in
-                                HStack {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(plugin.name)
-                                            .fontWeight(.medium)
-                                        Text(plugin.path)
-                                            .font(.caption)
-                                            .foregroundStyle(.tertiary)
-                                            .lineLimit(1)
-                                            .truncationMode(.middle)
+                        if !devPlugins.isEmpty {
+                            VStack(spacing: 0) {
+                                ForEach(devPlugins, id: \.id) { plugin in
+                                    HStack {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(plugin.name)
+                                                .fontWeight(.medium)
+                                            Text(plugin.path)
+                                                .font(.caption)
+                                                .foregroundStyle(.tertiary)
+                                                .lineLimit(1)
+                                                .truncationMode(.middle)
+                                        }
+                                        Spacer()
                                     }
-                                    Spacer()
+                                    .padding(.vertical, 4)
                                 }
-                                .padding(.vertical, 4)
                             }
                         }
-                    }
 
-                    Label(
-                        "Load plugins directly from a build directory for development."
-                            + " Use `make bundle` then point to the .statusplugin output.",
-                        systemImage: "hammer"
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                        Label(
+                            "Load plugins directly from a build directory for development."
+                                + " Use `make bundle` then point to the .statusplugin output.",
+                            systemImage: "hammer"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
             }
 
             // Restart prompt


### PR DESCRIPTION
## Summary

The Development section in Plugins preferences was always visible, cluttering the UI for regular users. This PR adds a Developer Mode toggle in About > Developer that controls visibility of the plugin development tools.

## Changes

- Add `devModeEnabled` boolean to `PreferencesModel` (default `false`)
- Persist as `devMode` in `GlobalConfig` (omitted from YAML when `false`)
- Add Developer Mode toggle with description in About section
- Conditionally show the Development GroupBox in Plugins section only when Dev Mode is enabled
- Include `devModeEnabled` in `resetAll()` so Reset All Settings clears it

## Notes

- `devMode` is stored as `Bool?` in config — `nil` (omitted) when disabled, `true` when enabled — keeping config.yml clean for non-developers