### PR TITLE
refactor: defer tag/release creation to after PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Select Xcode 26
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '26'
-
       - name: Calculate next version
         id: version
         run: |
@@ -110,30 +105,8 @@ jobs:
           git add Resources/Info.plist CHANGELOG.md
           git commit -m "chore: release ${TAG}"
 
-      - name: Build & Package
-        run: make package
-
-      - name: Push branch and tag
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          BRANCH="release/${TAG}"
-          git tag "$TAG"
-          git push origin "$BRANCH" "$TAG"
-
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          PREV="${{ steps.version.outputs.previous_tag }}"
-          NOTES_FLAG="--generate-notes"
-          if [ "$PREV" != "v0.0.0" ]; then
-            NOTES_FLAG="--generate-notes --notes-start-tag ${PREV}"
-          fi
-          gh release create "$TAG" \
-            StatusBar.zip \
-            --title "$TAG" \
-            $NOTES_FLAG
+      - name: Push branch
+        run: git push origin release/${{ steps.version.outputs.tag }}
 
       - name: Create version bump PR
         env:

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,15 +1,29 @@
-name: Update Homebrew
+name: Publish Release
 
 on:
   pull_request:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
-  update-homebrew:
+  publish:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    runs-on: ubuntu-latest
+    runs-on: macos-26
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode 26
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26'
+
       - name: Extract version tag
         id: version
         run: |
@@ -17,10 +31,45 @@ jobs:
           TAG="${BRANCH#release/}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      - name: Create Homebrew formula PR
+          # Find previous tag for release notes
+          PREV=$(git tag -l 'v*' --sort=-v:refname | head -1)
+          if [ -z "$PREV" ]; then
+            PREV="v0.0.0"
+          fi
+          echo "previous_tag=${PREV}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Build & Package
+        run: make package
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          PREV="${{ steps.version.outputs.previous_tag }}"
+          NOTES_FLAG="--generate-notes"
+          if [ "$PREV" != "v0.0.0" ]; then
+            NOTES_FLAG="--generate-notes --notes-start-tag ${PREV}"
+          fi
+          gh release create "$TAG" \
+            StatusBar.zip \
+            --title "$TAG" \
+            $NOTES_FLAG
+
+  update-homebrew:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
+          TAG: ${{ needs.publish.outputs.tag }}
           REPO: ${{ github.repository }}
         run: |
           if [ -z "$GH_TOKEN" ]; then


### PR DESCRIPTION
## Summary

Restructure the release pipeline so that git tags, GitHub releases, and Homebrew formula updates only happen **after** the version-bump PR is merged — not before.

## Changes

- **`release.yml`**: Remove tag push, build, and GitHub release steps. The workflow now stops after creating the version-bump PR. Also remove the now-unnecessary Xcode setup from the release job.
- **`update-homebrew.yml`** (renamed to "Publish Release"): Add a `publish` job that runs on PR merge from `release/*` branches — creates the tag, builds the app, and publishes the GitHub release. The existing Homebrew update logic moves to a dependent `update-homebrew` job.

## Notes

**Before:**
```
workflow_dispatch → test → tag + build + release + PR (parallel Homebrew update)
                                                      ↑ can't stop if PR rejected
```

**After:**
```
workflow_dispatch → test → PR only
PR merge → tag + build + release → Homebrew update
```