### PR TITLE
refactor: check for updates via Homebrew instead of GitHub Releases API

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -56,3 +56,4 @@
 --disable environmentEntry
 --disable sortSwitchCases
 --disable wrapSwitchCases
+--disable modifierOrder        # defer to SwiftLint modifier_order

--- a/Sources/StatusBar/Services/AppUpdateService.swift
+++ b/Sources/StatusBar/Services/AppUpdateService.swift
@@ -47,7 +47,7 @@ final class AppUpdateService {
     private(set) var updateProgress: Double = 0
     private var updateProcess: Process?
 
-    private nonisolated static let brewFormula = "hytfjwr/statusbar/statusbar"
+    nonisolated private static let brewFormula = "hytfjwr/statusbar/statusbar"
 
     /// Minimum interval between automatic checks (1 hour).
     private static let autoCheckInterval: TimeInterval = 3_600
@@ -292,7 +292,7 @@ final class AppUpdateService {
         return status
     }
 
-    private nonisolated func fetchBrewLatestVersion() async throws -> String {
+    nonisolated private func fetchBrewLatestVersion() async throws -> String {
         let output = try await ShellCommand.run(
             "brew", arguments: ["info", "--json=v2", Self.brewFormula], timeout: 10
         )


### PR DESCRIPTION
## Summary

Replace the GitHub Releases API version check with `brew info --json=v2` so the update detection is consistent with what `brew upgrade` can actually install.

## Changes

- Replace `fetchLatestRelease()` (GitHub API) with `fetchBrewLatestVersion()` using `ShellCommand.run()`
- Remove `GitHubRelease` model and GitHub-specific error cases (`networkError`, `rateLimited`, `noRelease`)
- Nest `BrewCask` inside `BrewInfoResponse` for cleaner scoping
- Gain timeout protection (10s) and non-blocking async execution via existing `ShellCommand` utility

## Notes

- The release workflow creates a GitHub release tag first, then updates the Homebrew formula — this caused a window where the app would detect an update that `brew upgrade` couldn't yet install
- `ShellCommand.run()` resolves `brew` via `/usr/bin/env` with a PATH that includes `/opt/homebrew/bin` and `/usr/local/bin`, so the manual `findBrewPath()` lookup is no longer needed for version checks (still used by `performUpdate()` for streaming output)