### PR TITLE
fix: use bundle ID for relaunch to survive brew upgrade path changes

### DIFF
--- a/Sources/StatusBar/Services/AppUpdateService.swift
+++ b/Sources/StatusBar/Services/AppUpdateService.swift
@@ -182,7 +182,17 @@ final class AppUpdateService {
         let pid = ProcessInfo.processInfo.processIdentifier
 
         let targetPath = isAppBundle ? bundlePath : ProcessInfo.processInfo.arguments[0]
-        let launchCmd = isAppBundle ? #"open "$2""# : #""$2" &"#
+        let bundleId = Bundle.main.bundleIdentifier
+        let launchCmd = if isAppBundle, let bundleId {
+            // Use bundle ID instead of path — the Cellar path from
+            // Bundle.main.bundlePath is deleted after `brew upgrade`,
+            // but Launch Services can still locate the app by its ID.
+            #"open -b "\#(bundleId)""#
+        } else if isAppBundle {
+            #"open "$2""#
+        } else {
+            #""$2" &"#
+        }
 
         // The shell script waits for the current process to fully exit before
         // relaunching to avoid the single-instance guard killing the new process.


### PR DESCRIPTION
## Summary

After a Homebrew upgrade, clicking **Restart** in the update window stops the app but fails to relaunch it.

## Root Cause

`Bundle.main.bundlePath` resolves symlinks, returning the versioned Cellar path (e.g. `/opt/homebrew/Cellar/statusbar/0.5.0/StatusBar.app`). `brew upgrade` deletes that directory when installing the new version, so the relaunch script's `open` command fails:

```
The file /opt/homebrew/Cellar/statusbar/0.5.0/StatusBar.app does not exist.
```

## Fix

Replace path-based `open "/path/to/app"` with bundle-ID-based `open -b <bundle-id>`. macOS Launch Services locates the app by its identifier regardless of its on-disk path, so it finds the newly installed version after the upgrade.

Falls back to the original path-based launch for:
- `.app` bundles without a `CFBundleIdentifier` (defensive)
- Bare executables (development builds)

## Test Plan

- [ ] `swift build` passes
- [ ] Verify `/tmp/statusbar-relaunch.log` shows `open -b io.github.hytfjwr.StatusBar` after clicking Restart
- [ ] Homebrew install: `brew upgrade` → Restart → app relaunches successfully
- [ ] Development build: relaunch still works via direct executable path