### PR TITLE
fix: use /Applications symlink for relaunch instead of Launch Services

### DIFF
--- a/Sources/StatusBar/Services/AppUpdateService.swift
+++ b/Sources/StatusBar/Services/AppUpdateService.swift
@@ -175,14 +175,10 @@ final class AppUpdateService {
         let pid = ProcessInfo.processInfo.processIdentifier
 
         let targetPath = isAppBundle ? bundlePath : ProcessInfo.processInfo.arguments[0]
-        let bundleId = Bundle.main.bundleIdentifier
-        let launchCmd = if isAppBundle, let bundleId {
-            // Use bundle ID instead of path — the Cellar path from
-            // Bundle.main.bundlePath is deleted after `brew upgrade`,
-            // but Launch Services can still locate the app by its ID.
-            #"open -b "\#(bundleId)""#
-        } else if isAppBundle {
-            #"open "$2""#
+        let launchCmd = if isAppBundle {
+            // Prefer /Applications symlink which survives `brew upgrade` path changes.
+            // Fall back to the original path ($2) for non-Homebrew installs.
+            #"if [ -e "/Applications/StatusBar.app" ]; then open "/Applications/StatusBar.app"; else open "$2"; fi"#
         } else {
             #""$2" &"#
         }


### PR DESCRIPTION
## Summary

After `brew upgrade`, the app relaunches an old version instead of the updated one. This happened because `open -b <bundleId>` resolves through Launch Services, which caches stale Cellar paths from previous Homebrew installs and falls back to whichever registered copy still exists on disk (e.g. a dev build).

## Changes

- Replace `open -b <bundleId>` with `open /Applications/StatusBar.app`, which follows the Homebrew symlink chain (`/Applications/StatusBar.app` → `/opt/homebrew/opt/statusbar/StatusBar.app` → current Cellar version)
- Fall back to the original path (`$2`) for non-Homebrew installs
- Remove unused `bundleId` variable

## Notes

Root cause investigation: the Launch Services database (`lsregister`) had entries for every old Cellar version (0.3.0–0.5.2) but not the newly installed 0.5.3. Since all old Cellar paths were cleaned up by `brew cleanup`, LS resolved the bundle ID to the only remaining registered copy — a stale dev build at `~/Dev/poc/.../StatusBar.app` (v0.4.0).