### PR TITLE
feat: add menu bar auto-hide recommendation to onboarding

### DIFF
--- a/Sources/StatusBar/Onboarding/OnboardingView.swift
+++ b/Sources/StatusBar/Onboarding/OnboardingView.swift
@@ -276,14 +276,11 @@ private struct MenuBarSetupPage: View {
                     .font(.title2)
                     .fontWeight(.semibold)
 
-                Text(
-                    "StatusBar works best when the built-in macOS menu bar is hidden."
-                        + "\nSet \"Automatically hide and show the menu bar\" to **Always** in System Settings."
-                )
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 420)
+                Text("StatusBar works best when the built-in macOS menu bar is hidden.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 420)
             }
 
             stepsView
@@ -300,14 +297,27 @@ private struct MenuBarSetupPage: View {
 
     private var stepsView: some View {
         VStack(alignment: .leading, spacing: 8) {
-            stepRow(number: 1, text: "System Settings → Control Center")
-            stepRow(number: 2, text: "Set \"Automatically hide and show the menu bar\" to **Always**")
+            StepRow(number: 1, text: "System Settings → Control Center")
+            StepRow(number: 2, text: "Set \"Automatically hide and show the menu bar\" to **Always**")
         }
         .padding(16)
         .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
     }
 
-    private func stepRow(number: Int, text: LocalizedStringKey) -> some View {
+    private func openControlCenterSettings() {
+        // swiftlint:disable:next force_unwrapping
+        let url = URL(string: "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension")!
+        NSWorkspace.shared.open(url)
+    }
+}
+
+// MARK: - StepRow
+
+private struct StepRow: View {
+    let number: Int
+    let text: LocalizedStringKey
+
+    var body: some View {
         HStack(alignment: .top, spacing: 10) {
             Text("\(number)")
                 .font(.system(size: 11, weight: .bold, design: .rounded))
@@ -318,12 +328,6 @@ private struct MenuBarSetupPage: View {
             Text(text)
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
-        }
-    }
-
-    private func openControlCenterSettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension") {
-            NSWorkspace.shared.open(url)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a new onboarding page that guides users to set macOS menu bar to "Automatically hide and show the menu bar" → **Always**
- Placed between Widgets and Tips pages (Welcome → Widgets → **Menu Bar Setup** → Tips)
- Includes a button that opens System Settings directly to Control Center preferences
- Shows numbered step-by-step instructions for the setting change

## Test plan

- [ ] Launch the app with onboarding not completed and verify the new page appears after Widgets
- [ ] Verify Back/Next navigation works correctly through all 4 pages
- [ ] Verify page indicator dots show 4 dots and highlight correctly
- [ ] Click "Open System Settings" button and verify it opens the correct Control Center pane
- [ ] Complete onboarding and verify "Get Started" still works on the Tips page