### PR TITLE
fix: use Homebrew Cask commands for update detection and upgrade

### DIFF
--- a/Sources/StatusBar/Services/AppUpdateService.swift
+++ b/Sources/StatusBar/Services/AppUpdateService.swift
@@ -299,6 +299,10 @@ final class AppUpdateService {
     }
 
     nonisolated private func fetchBrewLatestVersion() async throws -> String {
+        // Update local tap data so we see newly published versions.
+        // Failures are ignored — the info check still works with cached data.
+        _ = try? await ShellCommand.run("brew", arguments: ["update", "--quiet"], timeout: 30)
+
         let output = try await ShellCommand.run(
             "brew", arguments: ["info", "--json=v2", "--cask", Self.brewCask], timeout: 10
         )


### PR DESCRIPTION
## Summary

Fix the update checker that stopped detecting new versions after migrating Homebrew distribution from Formula to Cask (#48).

## Changes

- Add `--cask` flag to `brew info --json=v2` and `brew upgrade` commands
- Change Homebrew identifier from formula tap path (`hytfjwr/statusbar/statusbar`) to cask token (`statusbar`)
- Rename `brewFormula` → `brewCask`, `formulaNotFound` → `caskNotFound`

## Notes

The root cause was that `brew info --json=v2 hytfjwr/statusbar/statusbar` (without `--cask`) returns the response with an empty `casks` array, so the version check always threw `formulaNotFound`. Similarly, `brew upgrade` without `--cask` cannot upgrade a cask.