### PR TITLE
fix: kill running StatusBar process before launching new instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test:
 	swift test
 
 run-dev: build
+	@-pkill -x $(APP_NAME) 2>/dev/null && sleep 0.5 || true
 	@rm -rf $(DEBUG_BUNDLE)
 	@mkdir -p $(DEBUG_BUNDLE)/Contents/MacOS
 	@mkdir -p $(DEBUG_BUNDLE)/Contents/Frameworks
@@ -30,6 +31,7 @@ run-dev: build
 	open $(DEBUG_BUNDLE)
 
 run-app: bundle
+	@-pkill -x $(APP_NAME) 2>/dev/null && sleep 0.5 || true
 	open $(APP_BUNDLE)
 
 bundle: release


### PR DESCRIPTION
Add `pkill -x StatusBar` to both `run-dev` and `run-app` Makefile targets so that any already-running instance is terminated before opening the newly built app. The kill is non-fatal (ignored if no process exists) and includes a short sleep to let the process fully exit.