### PR TITLE
fix: align CLI reload command with Apple Menu behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ sbar set --global bar.height=44
 sbar set --global appearance.accent=#FF0000
 sbar set --global behavior.autoHide=false
 
-# Reload configuration from disk
+# Relaunch the app
 sbar reload
 ```
 

--- a/Sources/StatusBar/IPC/Handlers/ReloadCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/ReloadCommandHandler.swift
@@ -5,7 +5,7 @@ struct ReloadCommandHandler: CommandHandling {
     let commandKey = "reload"
 
     func handle(_ command: IPCCommand) throws -> IPCPayload {
-        ConfigLoader.shared.reloadFromDisk()
+        AppUpdateService.relaunchApp()
         return .ok
     }
 }

--- a/Sources/statusbar-cli/Commands/ReloadCommand.swift
+++ b/Sources/statusbar-cli/Commands/ReloadCommand.swift
@@ -4,7 +4,7 @@ import StatusBarIPC
 struct ReloadCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "reload",
-        abstract: "Reload configuration from disk"
+        abstract: "Relaunch the app"
     )
 
     func run() throws {


### PR DESCRIPTION
## Summary

The `sbar reload` CLI command previously only reloaded config from disk (`ConfigLoader.reloadFromDisk()`), while the Apple Menu "Reload" button relaunched the entire app (`AppUpdateService.relaunchApp()`). This was confusing since both are named "Reload" but behaved differently.

Now both perform a full app relaunch.

## Changes

- `ReloadCommandHandler`: call `AppUpdateService.relaunchApp()` instead of `ConfigLoader.shared.reloadFromDisk()`
- `ReloadCommand`: update CLI abstract to "Relaunch the app"
- `README.md`: update `sbar reload` comment to match new behavior