### PR TITLE
fix: handle expected read failure on sbar reload

### DIFF
--- a/Sources/statusbar-cli/Commands/ReloadCommand.swift
+++ b/Sources/statusbar-cli/Commands/ReloadCommand.swift
@@ -8,9 +8,13 @@ struct ReloadCommand: ParsableCommand {
     )
 
     func run() throws {
-        let payload = try IPCClient.send(.reload)
-        guard case .ok = payload else {
-            throw ExitCode.failure
+        do {
+            let payload = try IPCClient.send(.reload)
+            guard case .ok = payload else {
+                throw ExitCode.failure
+            }
+        } catch IPCClientError.readFailed {
+            // Expected: the app terminates before sending a response.
         }
         print("OK")
     }


### PR DESCRIPTION
After #69 aligned `sbar reload` to relaunch the app, the CLI now errors with "Failed to read response" because the app terminates before sending an IPC response back.

This treats `readFailed` as success for the reload command, since the connection drop confirms the app is relaunching.