### PR TITLE
feat: show update availability indicators in UI

### DIFF
--- a/Sources/StatusBar/Preferences/PreferencesView.swift
+++ b/Sources/StatusBar/Preferences/PreferencesView.swift
@@ -6,12 +6,21 @@ import SwiftUI
 struct PreferencesView: View {
     @Bindable var model: PreferencesModel
     @State private var selectedSection: PreferencesSection = .general
+    private let updateService = AppUpdateService.shared
 
     var body: some View {
         HStack(spacing: 0) {
             // Sidebar
             List(PreferencesSection.allCases, selection: $selectedSection) { section in
-                Label(section.title, systemImage: section.icon)
+                HStack {
+                    Label(section.title, systemImage: section.icon)
+                    if section == .about, updateService.isUpdateAvailable {
+                        Spacer()
+                        Circle()
+                            .fill(Theme.green)
+                            .frame(width: 8, height: 8)
+                    }
+                }
             }
             .listStyle(.sidebar)
             .frame(width: 170)

--- a/Sources/StatusBar/Services/AppUpdateService.swift
+++ b/Sources/StatusBar/Services/AppUpdateService.swift
@@ -59,6 +59,13 @@ final class AppUpdateService {
         }
     }
 
+    var isUpdateAvailable: Bool {
+        if case .available = state {
+            return true
+        }
+        return false
+    }
+
     // MARK: - Public API
 
     /// Check for updates. Called manually from UI or automatically on launch.

--- a/Sources/StatusBar/Widgets/AppleMenuWidget.swift
+++ b/Sources/StatusBar/Widgets/AppleMenuWidget.swift
@@ -14,6 +14,7 @@ final class AppleMenuWidget: StatusBarWidget {
     }
 
     private var popupPanel: PopupPanel?
+    private let updateService = AppUpdateService.shared
 
     func start() {}
     func stop() {
@@ -25,6 +26,14 @@ final class AppleMenuWidget: StatusBarWidget {
             .font(Theme.sfIconFont)
             .foregroundStyle(.primary)
             .padding(.horizontal, 4)
+            .overlay(alignment: .topTrailing) {
+                if updateService.isUpdateAvailable {
+                    Circle()
+                        .fill(Theme.green)
+                        .frame(width: 6, height: 6)
+                        .offset(x: 2, y: -2)
+                }
+            }
             .contentShape(Rectangle())
             .onTapGesture { [weak self] in
                 self?.togglePopup()
@@ -62,6 +71,7 @@ struct AppleMenuPopupContent: View {
     let dismiss: () -> Void
 
     @State private var confirmAction: SystemAction?
+    private let updateService = AppUpdateService.shared
 
     private enum SystemAction: String, Identifiable {
         case lockScreen = "Lock Screen"
@@ -122,6 +132,10 @@ struct AppleMenuPopupContent: View {
 
                 VStack(spacing: 2) {
                     PopupRow(icon: "gearshape", label: "Preferences") {
+                        if updateService.isUpdateAvailable {
+                            PopupStatusBadge("Update", color: Theme.green)
+                        }
+                    } action: {
                         PreferencesWindow.shared.show()
                         dismiss()
                     }


### PR DESCRIPTION
## Summary
Show visual indicators across the UI when a new app version is available via Homebrew, so users can discover updates without manually checking.

## Changes
- **AppUpdateService**: Add `isUpdateAvailable` computed property to centralize the `if case .available` state check
- **Apple menu icon**: Green dot overlay (6pt) on the bar icon
- **Popup menu**: "Update" badge (PopupStatusBadge) on the Preferences row
- **Preferences sidebar**: Green dot (8pt) next to the "About" section label

## Notes
- All indicators are reactive via `@Observable` — they appear/disappear automatically when `AppUpdateService.state` changes
- The existing `PopupStatusBadge` component from StatusBarKit is reused for the popup badge