### PR TITLE
fix: preserve plugin order on update

### DIFF
--- a/Sources/StatusBar/Plugins/PluginStore.swift
+++ b/Sources/StatusBar/Plugins/PluginStore.swift
@@ -100,11 +100,14 @@ final class PluginStore {
     // MARK: - CRUD
 
     func add(_ record: InstalledPluginRecord) throws {
-        let isUpdate = plugins.contains { $0.id == record.id }
-        plugins.removeAll { $0.id == record.id }
-        plugins.append(record)
+        let existingIndex = plugins.firstIndex { $0.id == record.id }
+        if let index = existingIndex {
+            plugins[index] = record
+        } else {
+            plugins.append(record)
+        }
         try save()
-        if isUpdate {
+        if existingIndex != nil {
             logger.info("Updated plugin record: \(record.name) (\(record.id))")
         } else {
             logger.info("Added plugin record: \(record.name) (\(record.id))")

--- a/Tests/StatusBarTests/PluginStorePersistenceTests.swift
+++ b/Tests/StatusBarTests/PluginStorePersistenceTests.swift
@@ -56,6 +56,22 @@ struct PluginStorePersistenceTests {
         #expect(store.plugins.count == 2)
     }
 
+    @Test("add with existing ID preserves original position")
+    func addPreservesOrder() throws {
+        let (store, _, cleanup) = makeTempStore()
+        defer { cleanup() }
+        try store.add(makeRecord(id: "a", name: "A"))
+        try store.add(makeRecord(id: "b", name: "B"))
+        try store.add(makeRecord(id: "c", name: "C"))
+        try store.add(makeRecord(id: "a", name: "A-updated", version: "2.0.0"))
+        #expect(store.plugins.count == 3)
+        #expect(store.plugins[0].id == "a")
+        #expect(store.plugins[0].name == "A-updated")
+        #expect(store.plugins[0].version == "2.0.0")
+        #expect(store.plugins[1].id == "b")
+        #expect(store.plugins[2].id == "c")
+    }
+
     // MARK: - Remove
 
     @Test("remove deletes the record by ID")


### PR DESCRIPTION
## Summary
Fix plugin ordering in Preferences changing after updates.

## Changes
- `PluginStore.add()` now replaces records in-place instead of removing and appending, preserving the original display order
- Added test verifying order preservation when updating an existing plugin

## Notes
The root cause was `removeAll { $0.id == record.id }` + `append(record)`, which moved the updated plugin to the end of the array. The fix uses `firstIndex` + direct subscript assignment to keep the plugin at its original position.