### PR TITLE
feat: smooth widget visibility transitions

### DIFF
--- a/Sources/StatusBar/Core/BarContentView.swift
+++ b/Sources/StatusBar/Core/BarContentView.swift
@@ -13,6 +13,7 @@ struct BarContentView: View {
             HStack(spacing: Theme.widgetSpacing) {
                 ForEach(registry.centerWidgets) { widget in
                     widget.body()
+                        .transition(.widgetAppear)
                 }
             }
 
@@ -21,6 +22,7 @@ struct BarContentView: View {
                 HStack(spacing: Theme.widgetSpacing) {
                     ForEach(registry.leftWidgets) { widget in
                         widget.body()
+                            .transition(.widgetAppear)
                     }
                 }
                 .padding(.leading, Theme.widgetPaddingH)
@@ -30,6 +32,7 @@ struct BarContentView: View {
                 HStack(spacing: Theme.widgetSpacing) {
                     ForEach(registry.rightWidgets) { widget in
                         widget.body()
+                            .transition(.widgetAppear)
                     }
                 }
                 .padding(.trailing, Theme.widgetPaddingH)

--- a/Sources/StatusBar/Core/WidgetRegistry.swift
+++ b/Sources/StatusBar/Core/WidgetRegistry.swift
@@ -218,7 +218,9 @@ final class WidgetRegistry: WidgetRegistryProtocol {
         guard let index = layout.firstIndex(where: { $0.id == widgetID }) else {
             return
         }
-        layout[index].isVisible = visible
+        withAnimation(.widgetTransition) {
+            layout[index].isVisible = visible
+        }
 
         if visible {
             allWidgets[widgetID]?.start()

--- a/Sources/StatusBar/Core/WidgetTransition.swift
+++ b/Sources/StatusBar/Core/WidgetTransition.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+extension Animation {
+    static let widgetTransition: Animation = .spring(duration: 0.3, bounce: 0.15)
+}
+
+extension AnyTransition {
+    /// Slide + fade: width expands from zero on the leading edge, opacity 0→1.
+    @MainActor static let widgetAppear: AnyTransition = .modifier(
+        active: WidgetInsertModifier(progress: 0),
+        identity: WidgetInsertModifier(progress: 1)
+    )
+}
+
+// MARK: - WidgetInsertModifier
+
+private struct WidgetInsertModifier: ViewModifier {
+    let progress: Double
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(progress)
+            .scaleEffect(x: progress, y: 1, anchor: .leading)
+            .clipped()
+    }
+}

--- a/Sources/StatusBar/Widgets/MicCameraWidget.swift
+++ b/Sources/StatusBar/Widgets/MicCameraWidget.swift
@@ -91,27 +91,30 @@ final class MicCameraWidget: StatusBarWidget, EventEmitting {
         }
     }
 
-    @ViewBuilder
     func body() -> some View {
-        if micActive || cameraActive {
-            HStack(spacing: 4) {
-                if micActive {
-                    Image(systemName: "mic.fill")
-                        .font(Theme.sfIconFont)
-                        .foregroundStyle(Theme.red)
+        Group {
+            if micActive || cameraActive {
+                HStack(spacing: 4) {
+                    if micActive {
+                        Image(systemName: "mic.fill")
+                            .font(Theme.sfIconFont)
+                            .foregroundStyle(Theme.red)
+                    }
+                    if cameraActive {
+                        Image(systemName: "video.fill")
+                            .font(Theme.sfIconFont)
+                            .foregroundStyle(Theme.red)
+                    }
                 }
-                if cameraActive {
-                    Image(systemName: "video.fill")
-                        .font(Theme.sfIconFont)
-                        .foregroundStyle(Theme.red)
-                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .glassEffect(.regular, in: .rect(cornerRadius: 4))
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Microphone and Camera")
+                .accessibilityValue(accessibilityStateDescription)
+                .transition(.widgetAppear)
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .glassEffect(.regular, in: .rect(cornerRadius: 4))
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Microphone and Camera")
-            .accessibilityValue(accessibilityStateDescription)
         }
+        .animation(.widgetTransition, value: micActive || cameraActive)
     }
 }


### PR DESCRIPTION
## Summary
Adds spring-based slide+fade animations when widgets are toggled visible/hidden, replacing the previous instant appear/disappear behavior.

## Changes
- **WidgetTransition.swift** (new): Defines `Animation.widgetTransition` (0.3s spring with subtle bounce) and `AnyTransition.widgetAppear` (opacity + horizontal scaleEffect + clipped)
- **WidgetRegistry.swift**: Wraps layout mutation in `withAnimation(.widgetTransition)` inside `setVisible()` to reliably drive ForEach structural animations
- **BarContentView.swift**: Applies `.transition(.widgetAppear)` to all widget body views across LEFT/CENTER/RIGHT sections
- **MicCameraWidget.swift**: Wraps content-conditional rendering in `Group` with `.transition` and `.animation(value:)` for smooth mic/camera indicator appearance

## Notes
- `withAnimation` at the mutation site is used instead of `.animation(value:)` on ForEach — the latter does not reliably catch `@Observable` ForEach identity changes
- MicCameraWidget has its own animation scope because it conditionally renders *within* its body (unlike other widgets which are added/removed from the ForEach list)
- `@MainActor` on `AnyTransition.widgetAppear` is required — `AnyTransition` is not `Sendable` in Swift 6.2 strict concurrency