### PR TITLE
chore: add pre-commit hooks and unify SwiftLint to SPM plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install tools
-        run: brew install swiftlint swiftformat
-
       - name: SwiftLint
-        run: swiftlint lint --strict
+        run: swift package plugin --allow-writing-to-package-directory swiftlint lint --strict
+
+      - name: Install SwiftFormat
+        run: brew install swiftformat
 
       - name: SwiftFormat check
         run: swiftformat --lint .

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ setup:
 	@echo "Git hooks configured (scripts/pre-commit)"
 
 lint:
-	swiftlint lint --strict
+	swift package plugin --allow-writing-to-package-directory swiftlint lint --strict
 
 format:
 	swiftformat .

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -22,16 +22,12 @@ else
     echo "warning: swiftformat not installed, skipping format check"
 fi
 
-# --- SwiftLint ---
-if command -v swiftlint &>/dev/null; then
-    echo "-> swiftlint"
-    echo "$staged_files" | xargs swiftlint lint --quiet --strict 2>&1 || {
-        echo ""
-        echo "SwiftLint violations found. Fix them before committing."
-        exit 1
-    }
-else
-    echo "warning: swiftlint not installed, skipping lint check"
-fi
+# --- SwiftLint (via SPM plugin, version locked in Package.resolved) ---
+echo "-> swiftlint"
+swift package plugin --allow-writing-to-package-directory swiftlint lint --strict -- "$staged_files" 2>&1 || {
+    echo ""
+    echo "SwiftLint violations found. Fix them before committing."
+    exit 1
+}
 
 echo "Pre-commit checks passed."


### PR DESCRIPTION
## Summary
- Add `scripts/pre-commit` hook that runs SwiftFormat (lint mode) and SwiftLint on staged `.swift` files before each commit
- Add Makefile targets: `setup` (configure git hooks path), `lint`, `format`, `format-check`
- Unify SwiftLint execution to SPM plugin (`swift package plugin swiftlint`) across CI, Makefile, and pre-commit hook to eliminate version mismatch between local and CI

## Test plan
- [x] `make setup` correctly sets `core.hooksPath` to `scripts/`
- [x] `make lint` runs SwiftLint via SPM plugin (0 violations)
- [x] `make format-check` runs SwiftFormat in lint mode (0 files need formatting)
- [ ] Committing a file with lint/format violations is blocked by the hook