### PR TITLE
feat: split next event toggle into bar and popup settings

### DIFF
--- a/Sources/StatusBar/Preferences/Sections/WidgetSettingsSheet.swift
+++ b/Sources/StatusBar/Preferences/Sections/WidgetSettingsSheet.swift
@@ -90,11 +90,13 @@ struct TimeWidgetSettings: View {
 
 struct DateWidgetSettings: View {
     @State private var format: String
-    @State private var showNextEvent: Bool
+    @State private var showNextEventOnBar: Bool
+    @State private var showNextEventInPopup: Bool
 
     init() {
         _format = State(initialValue: DateSettings.shared.format)
-        _showNextEvent = State(initialValue: DateSettings.shared.showNextEvent)
+        _showNextEventOnBar = State(initialValue: DateSettings.shared.showNextEventOnBar)
+        _showNextEventInPopup = State(initialValue: DateSettings.shared.showNextEventInPopup)
     }
 
     var body: some View {
@@ -122,12 +124,21 @@ struct DateWidgetSettings: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
 
-            Toggle("Show Next Event", isOn: $showNextEvent)
-                .onChange(of: showNextEvent) { _, newValue in
-                    DateSettings.shared.showNextEvent = newValue
+            Toggle("Show on Bar", isOn: $showNextEventOnBar)
+                .onChange(of: showNextEventOnBar) { _, newValue in
+                    DateSettings.shared.showNextEventOnBar = newValue
                 }
 
             Text("Shows the next upcoming event with countdown and join button on the bar.")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+
+            Toggle("Show in Popup", isOn: $showNextEventInPopup)
+                .onChange(of: showNextEventInPopup) { _, newValue in
+                    DateSettings.shared.showNextEventInPopup = newValue
+                }
+
+            Text("Shows the \"Next Up\" section at the top of the calendar popup.")
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
         }

--- a/Sources/StatusBar/Widgets/DateWidget.swift
+++ b/Sources/StatusBar/Widgets/DateWidget.swift
@@ -43,7 +43,13 @@ final class DateSettings: WidgetConfigProvider {
         } }
     }
 
-    var showNextEvent: Bool {
+    var showNextEventOnBar: Bool {
+        didSet { if !suppressWrite {
+            WidgetConfigRegistry.shared.notifySettingsChanged()
+        } }
+    }
+
+    var showNextEventInPopup: Bool {
         didSet { if !suppressWrite {
             WidgetConfigRegistry.shared.notifySettingsChanged()
         } }
@@ -52,14 +58,18 @@ final class DateSettings: WidgetConfigProvider {
     private init() {
         let cfg = WidgetConfigRegistry.shared.values(for: "date")
         format = cfg?["format"]?.stringValue ?? "EEE dd. MMM"
-        showNextEvent = cfg?["showNextEvent"]?.boolValue ?? true
+
+        showNextEventOnBar = cfg?["showNextEventOnBar"]?.boolValue ?? true
+        showNextEventInPopup = cfg?["showNextEventInPopup"]?.boolValue ?? true
+
         WidgetConfigRegistry.shared.register(self)
     }
 
     func exportConfig() -> [String: ConfigValue] {
         [
             "format": .string(format),
-            "showNextEvent": .bool(showNextEvent),
+            "showNextEventOnBar": .bool(showNextEventOnBar),
+            "showNextEventInPopup": .bool(showNextEventInPopup),
         ]
     }
 
@@ -69,8 +79,11 @@ final class DateSettings: WidgetConfigProvider {
         if let v = values["format"]?.stringValue {
             format = v
         }
-        if let v = values["showNextEvent"]?.boolValue {
-            showNextEvent = v
+        if let v = values["showNextEventOnBar"]?.boolValue {
+            showNextEventOnBar = v
+        }
+        if let v = values["showNextEventInPopup"]?.boolValue {
+            showNextEventInPopup = v
         }
     }
 }
@@ -118,7 +131,7 @@ final class DateWidget: StatusBarWidget, EventEmitting {
     private func startTrackerIfNeeded() {
         tracker?.stop()
         tracker = nil
-        guard DateSettings.shared.showNextEvent else {
+        guard DateSettings.shared.showNextEventOnBar || DateSettings.shared.showNextEventInPopup else {
             nextEvent = nil
             timeUntilStart = nil
             return
@@ -164,7 +177,8 @@ final class DateWidget: StatusBarWidget, EventEmitting {
     private func observeSettings() {
         withObservationTracking {
             _ = DateSettings.shared.format
-            _ = DateSettings.shared.showNextEvent
+            _ = DateSettings.shared.showNextEventOnBar
+            _ = DateSettings.shared.showNextEventInPopup
         } onChange: { [weak self] in
             Task { @MainActor in
                 self?.applyFormat()
@@ -192,7 +206,7 @@ final class DateWidget: StatusBarWidget, EventEmitting {
                     self?.togglePopup()
                 }
 
-            if DateSettings.shared.showNextEvent {
+            if DateSettings.shared.showNextEventOnBar {
                 nextEventPill()
             }
         }
@@ -314,7 +328,7 @@ struct CalendarPopupContent: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if let nextEvent {
+            if DateSettings.shared.showNextEventInPopup, let nextEvent {
                 nextUpSection(event: nextEvent)
                     .padding(12)
 


### PR DESCRIPTION
## Summary
Split the single `showNextEvent` toggle into two independent settings so users can control next event visibility separately for the status bar and the calendar popup.

## Changes
- `DateSettings`: replaced `showNextEvent` with `showNextEventOnBar` and `showNextEventInPopup`
- `DateWidget`: bar pill controlled by `showNextEventOnBar`, popup "Next Up" section controlled by `showNextEventInPopup`, tracker runs when either is enabled
- `DateWidgetSettings`: two separate toggles with descriptions in the preferences UI

## Test plan
- [ ] Toggle "Show on Bar" off → next event pill disappears from bar, "Next Up" still visible in popup
- [ ] Toggle "Show in Popup" off → "Next Up" section hidden in popup, bar pill still visible
- [ ] Both off → no calendar tracking, bar shows only date, popup shows no "Next Up"
- [ ] Both on → same behavior as before the change
- [ ] Fresh config (no prior settings) → both default to `true`