### PR TITLE
fix: filter Join button URLs to known meeting services

### DIFF
--- a/Sources/StatusBar/Services/CalendarService.swift
+++ b/Sources/StatusBar/Services/CalendarService.swift
@@ -150,7 +150,38 @@ struct CalendarEvent: Identifiable {
         types: NSTextCheckingResult.CheckingType.link.rawValue
     )
 
-    /// Extracts the first URL found in the given text fields using NSDataDetector.
+    private static let meetingDomains: [String] = [
+        "zoom.us",
+        "zoom.com",
+        "meet.google.com",
+        "teams.microsoft.com",
+        "teams.live.com",
+        "webex.com",
+        "chime.aws",
+        "gotomeeting.com",
+        "goto.com",
+        "bluejeans.com",
+        "facetime.apple.com",
+        "join.skype.com",
+        "meet.jit.si",
+        "whereby.com",
+        "gather.town",
+        "app.slack.com",
+    ]
+
+    static func isMeetingURL(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else {
+            return false
+        }
+        // Slack requires /huddle/ in the path to distinguish from regular channel links.
+        if host.hasSuffix("app.slack.com") {
+            return url.path.lowercased().contains("/huddle/")
+        }
+        return meetingDomains.contains { host == $0 || host.hasSuffix(".\($0)") }
+    }
+
+    /// Extracts the first meeting URL found in the given text fields.
+    /// Fields are checked in order so `location` is preferred over `notes`.
     static func extractURL(from texts: String?...) -> URL? {
         guard let detector = linkDetector else {
             return nil
@@ -160,10 +191,9 @@ struct CalendarEvent: Identifiable {
                 continue
             }
             let range = NSRange(text.startIndex..., in: text)
-            if let match = detector.firstMatch(in: text, range: range),
-               let url = match.url
-            {
-                return url
+            let matches = detector.matches(in: text, range: range)
+            if let meetingURL = matches.lazy.compactMap(\.url).first(where: isMeetingURL) {
+                return meetingURL
             }
         }
         return nil

--- a/Tests/StatusBarTests/NextEventTrackerTests.swift
+++ b/Tests/StatusBarTests/NextEventTrackerTests.swift
@@ -44,6 +44,60 @@ struct CalendarEventURLExtractionTests {
         let url = CalendarEvent.extractURL(from: "", "")
         #expect(url == nil)
     }
+
+    @Test
+    func ignoresNonMeetingURLs() {
+        let url = CalendarEvent.extractURL(
+            from: "https://mycompany.atlassian.net/wiki/spaces/ENG/pages/123",
+            "See https://jira.example.com/browse/PROJ-42"
+        )
+        #expect(url == nil)
+    }
+
+    @Test
+    func picksMeetingURLOverNonMeetingInSameField() {
+        let url = CalendarEvent.extractURL(
+            from: "Agenda: https://confluence.example.com/page/1 Join: https://zoom.us/j/999"
+        )
+        #expect(url == URL(string: "https://zoom.us/j/999"))
+    }
+
+    @Test
+    func fallsBackToNotesWhenLocationHasNoMeetingURL() {
+        let url = CalendarEvent.extractURL(
+            from: "Conference Room B",
+            "https://teams.microsoft.com/l/meetup-join/abc"
+        )
+        #expect(url?.host?.contains("teams.microsoft.com") == true)
+    }
+
+    @Test
+    func matchesSubdomainZoom() {
+        let url = CalendarEvent.extractURL(from: "https://us02web.zoom.us/j/456")
+        #expect(url?.host == "us02web.zoom.us")
+    }
+
+    @Test
+    func matchesSubdomainWebex() {
+        let url = CalendarEvent.extractURL(from: "https://company.webex.com/meet/user")
+        #expect(url?.host == "company.webex.com")
+    }
+
+    @Test
+    func allowsSlackHuddleURL() {
+        let url = CalendarEvent.extractURL(
+            from: "https://app.slack.com/huddle/T123/C456"
+        )
+        #expect(url != nil)
+    }
+
+    @Test
+    func rejectsSlackNonHuddleURL() {
+        let url = CalendarEvent.extractURL(
+            from: "https://app.slack.com/client/T123/C456"
+        )
+        #expect(url == nil)
+    }
 }
 
 // MARK: - NextEventSelectionTests


### PR DESCRIPTION
## Summary
The Join button on calendar events was opening non-meeting URLs (e.g. Confluence, Jira) when they appeared in the event location or notes. `extractURL` now checks against a whitelist of video-conferencing domains and ignores unrelated links.

## Changes
- Add `meetingDomains` whitelist covering Zoom, Google Meet, Teams, Webex, Chime, GoTo, BlueJeans, FaceTime, Skype, Jitsi, Whereby, Gather, and Slack Huddles
- Add `isMeetingURL()` with suffix matching for subdomains (e.g. `us02web.zoom.us`)
- Special-case Slack to only match `/huddle/` paths
- Refactor `extractURL` to scan all URLs per field and return the first meeting match
- Add 7 new test cases for domain filtering, subdomain matching, and Slack handling

## Test plan
- [x] `swift test` — 181 tests passing
- [ ] Verify Join button appears for Zoom/Meet/Teams calendar events
- [ ] Verify Join button does not appear for events with only Confluence/Jira links