### PR TITLE
feat: add toast notifications for upcoming calendar events

### DIFF
--- a/Sources/StatusBar/Preferences/Sections/WidgetSettingsSheet.swift
+++ b/Sources/StatusBar/Preferences/Sections/WidgetSettingsSheet.swift
@@ -236,15 +236,11 @@ private struct EventNotifyMinutesEditor: View {
             return
         }
         drafts.removeValue(forKey: oldValue)
-        if newValue != oldValue, !minutes.contains(newValue) {
-            if let idx = minutes.firstIndex(of: oldValue) {
-                minutes[idx] = newValue
-                minutes.sort()
-            }
-        } else if newValue == oldValue {
-            // no change
-        } else {
-            drafts[oldValue] = String(oldValue)
+        if newValue != oldValue, !minutes.contains(newValue),
+           let idx = minutes.firstIndex(of: oldValue)
+        {
+            minutes[idx] = newValue
+            minutes.sort()
         }
     }
 

--- a/Sources/StatusBar/Widgets/DateWidget.swift
+++ b/Sources/StatusBar/Widgets/DateWidget.swift
@@ -225,6 +225,11 @@ final class DateWidget: StatusBarWidget, EventEmitting {
             }
             notifiedThresholds.insert(minutes)
             let message = minutes == 1 ? "Starting in 1 minute" : "Starting in \(minutes) minutes"
+            let joinAction: (@MainActor () -> Void)? = if let url = event.url {
+                { NSWorkspace.shared.open(url) }
+            } else {
+                nil
+            }
             ToastManager.shared.post(
                 ToastRequest(
                     title: event.title,
@@ -232,9 +237,9 @@ final class DateWidget: StatusBarWidget, EventEmitting {
                     icon: "calendar",
                     level: minutes <= 1 ? .warning : .info,
                     duration: 8,
-                    actionLabel: event.url != nil ? "Join" : nil,
-                    actionShellCommand: event.url.map { "open '\($0.absoluteString)'" }
-                )
+                    actionLabel: joinAction != nil ? "Join" : nil
+                ),
+                action: joinAction
             )
         }
     }


### PR DESCRIPTION
## Summary
- Add configurable toast notifications that fire before the next calendar event starts
- Users can enable/disable via a toggle and customize reminder times (default: 1, 5, 10 min) with editable text fields in Date widget settings
- Toast includes a "Join" button when the event has a meeting URL

## Changes
- **DateSettings**: new `notifyNextEvent` (bool) and `notifyMinutesBefore` (int array, persisted as CSV string) settings
- **DateWidget**: `checkEventNotifications()` fires toasts when remaining time crosses configured thresholds; uses stable event key (title+startDate) for dedup; resets state on tracker restart
- **DateWidgetSettings**: new "Toast Notification" section with enable toggle and `EventNotifyMinutesEditor` (add/remove/edit minute values)

## Notes
- `CalendarEvent.id` is a non-stable `UUID()` regenerated each tick, so notification dedup uses a derived key (`title-startDate`) instead
- Known limitation: duplicate events with identical title and start time share the same key, so the second event won't trigger its own notifications
- `ConfigValue` has no array case, so `notifyMinutesBefore` is serialized as a comma-separated string (e.g. `"1,5,10"`)