### PR TITLE
fix: notify all overlapping events, not just the first one

### DIFF
--- a/Sources/StatusBar/Services/NextEventTracker.swift
+++ b/Sources/StatusBar/Services/NextEventTracker.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Polls every 60s normally, switching to 30s when an event starts within 15 minutes.
 @MainActor
 final class NextEventTracker {
-    var onUpdate: ((CalendarEvent?, TimeInterval?) -> Void)?
+    var onUpdate: ((_ nextEvent: CalendarEvent?, _ timeUntilStart: TimeInterval?, _ upcoming: [CalendarEvent]) -> Void)?
 
     private var todayEvents: [CalendarEvent] = []
     private var timer: AnyCancellable?
@@ -44,11 +44,17 @@ final class NextEventTracker {
         events.first { !$0.isAllDay && $0.endDate > now }
     }
 
+    /// Returns all non-allDay events that haven't started yet.
+    nonisolated static func upcomingEvents(from events: [CalendarEvent], now: Date = Date()) -> [CalendarEvent] {
+        events.filter { !$0.isAllDay && $0.startDate > now }
+    }
+
     private func tick() {
         let now = Date()
         let event = Self.nextEvent(from: todayEvents, now: now)
         let timeUntilStart = event.map { $0.startDate.timeIntervalSince(now) }
-        onUpdate?(event, timeUntilStart)
+        let upcoming = Self.upcomingEvents(from: todayEvents, now: now)
+        onUpdate?(event, timeUntilStart, upcoming)
         scheduleTimer(timeUntilStart: timeUntilStart)
         scheduleMidnightRefresh()
     }

--- a/Sources/StatusBar/Widgets/DateWidget.swift
+++ b/Sources/StatusBar/Widgets/DateWidget.swift
@@ -142,8 +142,7 @@ final class DateWidget: StatusBarWidget, EventEmitting {
     private var nextEvent: CalendarEvent?
     private var timeUntilStart: TimeInterval?
     private var isLoadingEvents = true
-    private var notifiedEventKey: String?
-    private var notifiedThresholds: Set<Int> = []
+    private var notifiedThresholds: [String: Set<Int>] = [:]
 
     func start() {
         applyFormat()
@@ -164,8 +163,7 @@ final class DateWidget: StatusBarWidget, EventEmitting {
     private func startTrackerIfNeeded() {
         tracker?.stop()
         tracker = nil
-        notifiedEventKey = nil
-        notifiedThresholds = []
+        notifiedThresholds = [:]
         let settings = DateSettings.shared
         guard settings.showNextEventOnBar || settings.showNextEventInPopup || settings.notifyNextEvent else {
             nextEvent = nil
@@ -174,7 +172,7 @@ final class DateWidget: StatusBarWidget, EventEmitting {
         }
         isLoadingEvents = true
         let t = NextEventTracker()
-        t.onUpdate = { [weak self] event, interval in
+        t.onUpdate = { [weak self] event, interval, upcomingEvents in
             let changed = self?.nextEvent?.id != event?.id
             withAnimation(.numericTransition) {
                 self?.nextEvent = event
@@ -189,7 +187,7 @@ final class DateWidget: StatusBarWidget, EventEmitting {
                     timeUntilStart: interval
                 ))
             }
-            self?.checkEventNotifications(event: event, interval: interval)
+            self?.checkEventNotifications(upcomingEvents: upcomingEvents)
         }
         tracker = t
         Task { await t.start(calendarService: calendarService) }
@@ -199,48 +197,62 @@ final class DateWidget: StatusBarWidget, EventEmitting {
         "\(event.title)-\(event.startDate.timeIntervalSince1970)"
     }
 
-    private func checkEventNotifications(event: CalendarEvent?, interval: TimeInterval?) {
+    private func checkEventNotifications(upcomingEvents: [CalendarEvent]) {
         let settings = DateSettings.shared
-        guard settings.notifyNextEvent, let event, let interval, interval > 0 else {
+        guard settings.notifyNextEvent else {
             return
         }
 
-        let key = Self.eventKey(for: event)
-        if notifiedEventKey != key {
-            notifiedEventKey = key
-            notifiedThresholds = []
-            for minutes in settings.notifyMinutesBefore where interval <= Double(minutes) * 60 {
-                notifiedThresholds.insert(minutes)
-            }
-            return
-        }
+        let now = Date()
+        let activeKeys = Set(upcomingEvents.map { Self.eventKey(for: $0) })
+        notifiedThresholds = notifiedThresholds.filter { activeKeys.contains($0.key) }
 
-        for minutes in settings.notifyMinutesBefore.reversed() {
-            let thresholdSeconds = Double(minutes) * 60
-            guard interval <= thresholdSeconds else {
-                break
-            }
-            guard !notifiedThresholds.contains(minutes) else {
+        for event in upcomingEvents {
+            let interval = event.startDate.timeIntervalSince(now)
+            guard interval > 0 else {
                 continue
             }
-            notifiedThresholds.insert(minutes)
-            let message = minutes == 1 ? "Starting in 1 minute" : "Starting in \(minutes) minutes"
-            let joinAction: (@MainActor () -> Void)? = if let url = event.url {
-                { NSWorkspace.shared.open(url) }
-            } else {
-                nil
+
+            let key = Self.eventKey(for: event)
+
+            // First time seeing this event — pre-populate already-passed thresholds
+            if notifiedThresholds[key] == nil {
+                var initial: Set<Int> = []
+                for minutes in settings.notifyMinutesBefore where interval <= Double(minutes) * 60 {
+                    initial.insert(minutes)
+                }
+                notifiedThresholds[key] = initial
+                continue
             }
-            ToastManager.shared.post(
-                ToastRequest(
-                    title: event.title,
-                    message: message,
-                    icon: "calendar",
-                    level: minutes <= 1 ? .warning : .info,
-                    duration: 8,
-                    actionLabel: joinAction != nil ? "Join" : nil
-                ),
-                action: joinAction
-            )
+
+            for minutes in settings.notifyMinutesBefore.reversed() {
+                let thresholdSeconds = Double(minutes) * 60
+                guard interval <= thresholdSeconds else {
+                    break
+                }
+                guard notifiedThresholds[key]?.contains(minutes) != true else {
+                    continue
+                }
+
+                notifiedThresholds[key, default: []].insert(minutes)
+                let message = minutes == 1 ? "Starting in 1 minute" : "Starting in \(minutes) minutes"
+                let joinAction: (@MainActor () -> Void)? = if let url = event.url {
+                    { NSWorkspace.shared.open(url) }
+                } else {
+                    nil
+                }
+                ToastManager.shared.post(
+                    ToastRequest(
+                        title: event.title,
+                        message: message,
+                        icon: "calendar",
+                        level: minutes <= 1 ? .warning : .info,
+                        duration: 8,
+                        actionLabel: joinAction != nil ? "Join" : nil
+                    ),
+                    action: joinAction
+                )
+            }
         }
     }
 

--- a/Tests/StatusBarTests/NextEventTrackerTests.swift
+++ b/Tests/StatusBarTests/NextEventTrackerTests.swift
@@ -2,6 +2,25 @@ import Foundation
 @testable import StatusBar
 import Testing
 
+// MARK: - Test Helpers
+
+private func makeEvent(
+    title: String = "Test",
+    startDate: Date,
+    endDate: Date,
+    isAllDay: Bool = false
+) -> CalendarEvent {
+    CalendarEvent(
+        title: title,
+        startDate: startDate,
+        endDate: endDate,
+        isAllDay: isAllDay,
+        calendarColor: nil,
+        notes: nil,
+        url: nil
+    )
+}
+
 // MARK: - CalendarEventURLExtractionTests
 
 struct CalendarEventURLExtractionTests {
@@ -104,23 +123,6 @@ struct CalendarEventURLExtractionTests {
 
 struct NextEventSelectionTests {
 
-    private func makeEvent(
-        title: String = "Test",
-        startDate: Date,
-        endDate: Date,
-        isAllDay: Bool = false
-    ) -> CalendarEvent {
-        CalendarEvent(
-            title: title,
-            startDate: startDate,
-            endDate: endDate,
-            isAllDay: isAllDay,
-            calendarColor: nil,
-            notes: nil,
-            url: nil
-        )
-    }
-
     @Test
     func skipsEndedEvents() {
         let now = Date()
@@ -217,6 +219,67 @@ struct NextEventSelectionTests {
 
         let result = NextEventTracker.nextEvent(from: events, now: now)
         #expect(result == nil)
+    }
+}
+
+// MARK: - UpcomingEventsTests
+
+struct UpcomingEventsTests {
+
+    @Test
+    func returnsAllFutureEvents() {
+        let now = Date()
+        let events = [
+            makeEvent(title: "A", startDate: now.addingTimeInterval(600), endDate: now.addingTimeInterval(3_600)),
+            makeEvent(title: "B", startDate: now.addingTimeInterval(600), endDate: now.addingTimeInterval(3_600)),
+            makeEvent(title: "C", startDate: now.addingTimeInterval(1_800), endDate: now.addingTimeInterval(5_400)),
+        ]
+
+        let result = NextEventTracker.upcomingEvents(from: events, now: now)
+        #expect(result.count == 3)
+        #expect(result.map(\.title) == ["A", "B", "C"])
+    }
+
+    @Test
+    func excludesInProgressEvents() {
+        let now = Date()
+        let events = [
+            makeEvent(title: "InProgress", startDate: now.addingTimeInterval(-600), endDate: now.addingTimeInterval(1_800)),
+            makeEvent(title: "Future", startDate: now.addingTimeInterval(600), endDate: now.addingTimeInterval(3_600)),
+        ]
+
+        let result = NextEventTracker.upcomingEvents(from: events, now: now)
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Future")
+    }
+
+    @Test
+    func excludesAllDayEvents() {
+        let now = Date()
+        let events = [
+            makeEvent(
+                title: "AllDay",
+                startDate: now.addingTimeInterval(-3_600),
+                endDate: now.addingTimeInterval(36_000),
+                isAllDay: true
+            ),
+            makeEvent(title: "Timed", startDate: now.addingTimeInterval(600), endDate: now.addingTimeInterval(3_600)),
+        ]
+
+        let result = NextEventTracker.upcomingEvents(from: events, now: now)
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Timed")
+    }
+
+    @Test
+    func returnsEmptyWhenAllPast() {
+        let now = Date()
+        let events = [
+            makeEvent(title: "Done", startDate: now.addingTimeInterval(-3_600), endDate: now.addingTimeInterval(-1_800)),
+        ]
+
+        let result = NextEventTracker.upcomingEvents(from: events, now: now)
+        #expect(result.isEmpty)
     }
 }
 


### PR DESCRIPTION
## Summary

Toast notifications for upcoming calendar events only fired for the first event when multiple events shared the same start time. This was because `NextEventTracker` only exposed a single "next event" and the notification logic only tracked one event at a time.

## Changes

- Add `NextEventTracker.upcomingEvents(from:now:)` that returns all not-yet-started events (vs `nextEvent` which returns only the first)
- Pass the full upcoming list through the `onUpdate` callback
- Rewrite `checkEventNotifications` to iterate over all upcoming events with per-event threshold tracking (`[String: Set<Int>]` dictionary)
- Prune stale entries from `notifiedThresholds` when events end
- Deduplicate `makeEvent` test helper into a file-level function

## Notes

- The status bar pill still shows only the single next event — this change only affects toast notifications
- `CalendarEvent.id` is an ephemeral `UUID()` regenerated on each fetch, so `eventKey` uses title + startDate for stable cross-fetch identity