### PR TITLE
feat: expose Bluetooth device battery with low-battery alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ make run-app   # Release build
 | Network | Upload / download speeds | 2s |
 | Battery | Charge level & charging state | 60s |
 | Volume | Volume level with popup control | Event |
-| Bluetooth | Connected device count | 5s |
+| Bluetooth | Connected device count, AirPods L/R/Case battery in popup | 10s |
 | Disk Usage | Disk utilization percentage | 30s |
 | Mic / Camera | Active mic/camera indicator | Event |
 | Input Source | Keyboard input source | Event |
@@ -170,6 +170,8 @@ A default config is generated at `~/.config/statusbar/config.yml` on first launc
 | `memoryHigh` | bool | false | Enable high memory alert |
 | `memoryThreshold` | number | 90.0 | Memory usage (%) to trigger |
 | `memorySustainedDuration` | number | 5.0 | Seconds above threshold before alert |
+| `bluetoothBatteryLow` | bool | false | Enable low Bluetooth device battery alert (AirPods L/R, Magic Mouse, …) |
+| `bluetoothBatteryThreshold` | number | 20.0 | Device battery level (%) to trigger |
 
 </details>
 
@@ -284,6 +286,11 @@ sbar reload
 
 Use `--json` for machine-readable output (pipe to `jq` for filtering).
 
+`sbar get bluetooth --json` includes live connected-device state alongside settings:
+
+- `settings.state.deviceCount` — number of connected devices
+- `settings.state.devices` — JSON-encoded array of `{id, name, category, battery?, batteryLeft?, batteryRight?, batteryCase?}`. Decode with `jq -r '.settings["state.devices"] | fromjson'`.
+
 <details>
 <summary>Event subscription</summary>
 
@@ -312,13 +319,14 @@ Use `--json` for machine-readable output (pipe to `jq` for filtering).
 | `volume_unmuted` | — | Audio unmuted |
 | `mic_activated` / `mic_deactivated` | — | Microphone starts/stops |
 | `camera_activated` / `camera_deactivated` | — | Camera starts/stops |
-| `bluetooth_devices_changed` | `connectedCount`, `deviceNames` | Device list changes |
+| `bluetooth_devices_changed` | `connectedCount`, `deviceNames`, `devices[]` (`name`, `category`, optional `battery`/`batteryLeft`/`batteryRight`/`batteryCase`) | Device list changes |
 | `bluetooth_device_connected` | `name`, `category` | New device connected |
 | `bluetooth_device_disconnected` | `name` | Device disconnected |
 | `focus_timer_started` | `mode`, `durationSeconds` | Timer started |
 | `focus_timer_stopped` | — | Timer cancelled |
 | `focus_timer_completed` | `mode` | Timer finished |
 | `calendar_next_event_changed` | `title`, `startDate`, `timeUntilStartSeconds` | Next event changes |
+| `bluetooth_battery_low` | `deviceName`, `component` (`"left"`/`"right"`/`null`), `percent`, `threshold` | Connected device battery drops below threshold |
 
 **Threshold events** (emitted when crossing configured boundaries):
 
@@ -422,7 +430,7 @@ The `sbar set --global` command uses dot-separated key paths matching the YAML c
 | Typography | `typography.iconFontSize`, `typography.labelFontSize`, `typography.smallFontSize`, `typography.monoFontSize` |
 | Graphs | `graphs.width`, `graphs.height`, `graphs.dataPoints`, `graphs.cpuColor`, `graphs.memoryColor` |
 | Behavior | `behavior.autoHide`, `behavior.autoHideDwellTime`, `behavior.autoHideFadeDuration`, `behavior.launchAtLogin`, `behavior.hideInFullscreen` |
-| Notifications | `notifications.batteryLow`, `notifications.batteryThreshold`, `notifications.cpuHigh`, `notifications.cpuThreshold`, `notifications.memoryHigh`, `notifications.memoryThreshold` |
+| Notifications | `notifications.batteryLow`, `notifications.batteryThreshold`, `notifications.cpuHigh`, `notifications.cpuThreshold`, `notifications.memoryHigh`, `notifications.memoryThreshold`, `notifications.bluetoothBatteryLow`, `notifications.bluetoothBatteryThreshold` |
 
 </details>
 

--- a/Sources/StatusBar/App/AppDelegate.swift
+++ b/Sources/StatusBar/App/AppDelegate.swift
@@ -35,7 +35,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         registry.register(InputSourceWidget())
         registry.register(DateWidget())
         registry.register(TimeWidget())
-        registry.register(BluetoothWidget())
+        let bluetoothWidget = BluetoothWidget()
+        registry.register(bluetoothWidget)
+        BluetoothWidgetLocator.register(bluetoothWidget)
 
         // Dylib plugins (user-installed from ~/.config/statusbar/plugins/)
         DylibPluginLoader.shared.loadAll(into: registry)

--- a/Sources/StatusBar/Config/StatusBarConfig.swift
+++ b/Sources/StatusBar/Config/StatusBarConfig.swift
@@ -301,6 +301,8 @@ struct NotificationsConfig: Codable {
     var memoryHigh: Bool
     var memoryThreshold: Double
     var memorySustainedDuration: Double
+    var bluetoothBatteryLow: Bool
+    var bluetoothBatteryThreshold: Double
 
     init() {
         let d = PreferencesModel.Defaults.self
@@ -312,6 +314,8 @@ struct NotificationsConfig: Codable {
         memoryHigh = d.notifyMemoryHigh
         memoryThreshold = d.memoryThreshold
         memorySustainedDuration = d.memorySustainedDuration
+        bluetoothBatteryLow = d.notifyBluetoothBatteryLow
+        bluetoothBatteryThreshold = d.bluetoothBatteryThreshold
     }
 
     @MainActor
@@ -324,6 +328,8 @@ struct NotificationsConfig: Codable {
         memoryHigh = p.notifyMemoryHigh
         memoryThreshold = p.memoryThreshold
         memorySustainedDuration = p.memorySustainedDuration
+        bluetoothBatteryLow = p.notifyBluetoothBatteryLow
+        bluetoothBatteryThreshold = p.bluetoothBatteryThreshold
     }
 
     @MainActor
@@ -336,6 +342,31 @@ struct NotificationsConfig: Codable {
         p.notifyMemoryHigh = memoryHigh
         p.memoryThreshold = memoryThreshold
         p.memorySustainedDuration = memorySustainedDuration
+        p.notifyBluetoothBatteryLow = bluetoothBatteryLow
+        p.bluetoothBatteryThreshold = bluetoothBatteryThreshold
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let d = PreferencesModel.Defaults.self
+        batteryLow = try c.decodeIfPresent(Bool.self, forKey: .batteryLow) ?? d.notifyBatteryLow
+        batteryThreshold = try c.decodeIfPresent(Double.self, forKey: .batteryThreshold) ?? d.batteryThreshold
+        cpuHigh = try c.decodeIfPresent(Bool.self, forKey: .cpuHigh) ?? d.notifyCPUHigh
+        cpuThreshold = try c.decodeIfPresent(Double.self, forKey: .cpuThreshold) ?? d.cpuThreshold
+        cpuSustainedDuration = try c.decodeIfPresent(
+            Double.self, forKey: .cpuSustainedDuration
+        ) ?? d.cpuSustainedDuration
+        memoryHigh = try c.decodeIfPresent(Bool.self, forKey: .memoryHigh) ?? d.notifyMemoryHigh
+        memoryThreshold = try c.decodeIfPresent(Double.self, forKey: .memoryThreshold) ?? d.memoryThreshold
+        memorySustainedDuration = try c.decodeIfPresent(
+            Double.self, forKey: .memorySustainedDuration
+        ) ?? d.memorySustainedDuration
+        bluetoothBatteryLow = try c.decodeIfPresent(
+            Bool.self, forKey: .bluetoothBatteryLow
+        ) ?? d.notifyBluetoothBatteryLow
+        bluetoothBatteryThreshold = try c.decodeIfPresent(
+            Double.self, forKey: .bluetoothBatteryThreshold
+        ) ?? d.bluetoothBatteryThreshold
     }
 }
 

--- a/Sources/StatusBar/IPC/Handlers/GetWidgetCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/GetWidgetCommandHandler.swift
@@ -1,4 +1,7 @@
+import Foundation
 import StatusBarKit
+
+// MARK: - GetWidgetCommandHandler
 
 @MainActor
 struct GetWidgetCommandHandler: CommandHandling {
@@ -13,7 +16,85 @@ struct GetWidgetCommandHandler: CommandHandling {
             throw IPCError.widgetNotFound(id: id)
         }
 
-        let settings = WidgetConfigRegistry.shared.exportAll()[id] ?? [:]
+        var settings = WidgetConfigRegistry.shared.exportAll()[id] ?? [:]
+        mergeRuntimeState(id: id, into: &settings)
         return .widgetDetail(.make(from: entry, settings: settings))
+    }
+
+    /// Merge widget-specific runtime state into the settings map returned via IPC.
+    /// Keys are namespaced under `state.` to signal they are read-only and never
+    /// persisted to the YAML config. Plain scalars only (`ConfigValue` limitation);
+    /// structured values are JSON-encoded strings the caller decodes with `jq`.
+    private func mergeRuntimeState(id: String, into settings: inout [String: ConfigValue]) {
+        switch id {
+        case "bluetooth":
+            BluetoothRuntimeState.merge(into: &settings)
+        default:
+            break
+        }
+    }
+}
+
+// MARK: - BluetoothRuntimeState
+
+@MainActor
+private enum BluetoothRuntimeState {
+    static func merge(into settings: inout [String: ConfigValue]) {
+        guard let widget = BluetoothWidgetLocator.current else {
+            return
+        }
+        let devices = widget.currentDevices
+        settings["state.deviceCount"] = .int(devices.count)
+        if let json = encodeDevices(devices) {
+            settings["state.devices"] = .string(json)
+        }
+    }
+
+    private static func encodeDevices(_ devices: [BluetoothService.BluetoothDevice]) -> String? {
+        let payload = devices.map { device -> [String: Any] in
+            var entry: [String: Any] = [
+                "id": device.id,
+                "name": device.name,
+                "category": device.category.rawValue,
+            ]
+            if let b = device.batteryLevel {
+                entry["battery"] = b
+            }
+            if let l = device.leftBattery {
+                entry["batteryLeft"] = l
+            }
+            if let r = device.rightBattery {
+                entry["batteryRight"] = r
+            }
+            if let c = device.caseBattery {
+                entry["batteryCase"] = c
+            }
+            return entry
+        }
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.sortedKeys]
+        ) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+// MARK: - BluetoothWidgetLocator
+
+/// Holds a weak reference to the live `BluetoothWidget` so the IPC layer can
+/// query runtime state (connected devices, batteries) without importing the
+/// widget tree or owning it. Registered once in `AppDelegate` during widget setup.
+@MainActor
+enum BluetoothWidgetLocator {
+    private static weak var instance: BluetoothWidget?
+
+    static func register(_ widget: BluetoothWidget) {
+        instance = widget
+    }
+
+    static var current: BluetoothWidget? {
+        instance
     }
 }

--- a/Sources/StatusBar/IPC/Handlers/SetWidgetCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/SetWidgetCommandHandler.swift
@@ -21,6 +21,11 @@ struct SetWidgetCommandHandler: CommandHandling {
             return .ok
         }
 
+        // Read-only runtime state exposed by `get widget`; never persisted.
+        if key.hasPrefix("state.") {
+            throw IPCError.invalidValue(key: key, reason: "state.* keys are read-only runtime fields")
+        }
+
         let configRegistry = WidgetConfigRegistry.shared
         var allConfig = configRegistry.exportAll()
         var widgetConfig = allConfig[id] ?? [:]

--- a/Sources/StatusBar/Preferences/PreferencesModel.swift
+++ b/Sources/StatusBar/Preferences/PreferencesModel.swift
@@ -219,6 +219,14 @@ final class PreferencesModel: ThemeProvider {
         didSet { scheduleFlush(); bump() }
     }
 
+    var notifyBluetoothBatteryLow: Bool {
+        didSet { scheduleFlush(); bump() }
+    }
+
+    var bluetoothBatteryThreshold: Double {
+        didSet { scheduleFlush(); bump() }
+    }
+
     // MARK: - Developer
 
     var devModeEnabled: Bool {
@@ -349,6 +357,8 @@ final class PreferencesModel: ThemeProvider {
         notifyMemoryHigh = d.notifyMemoryHigh
         memoryThreshold = d.memoryThreshold
         memorySustainedDuration = d.memorySustainedDuration
+        notifyBluetoothBatteryLow = d.notifyBluetoothBatteryLow
+        bluetoothBatteryThreshold = d.bluetoothBatteryThreshold
 
         devModeEnabled = d.devModeEnabled
     }
@@ -430,6 +440,8 @@ final class PreferencesModel: ThemeProvider {
             notifyMemoryHigh = d.notifyMemoryHigh
             memoryThreshold = d.memoryThreshold
             memorySustainedDuration = d.memorySustainedDuration
+            notifyBluetoothBatteryLow = d.notifyBluetoothBatteryLow
+            bluetoothBatteryThreshold = d.bluetoothBatteryThreshold
         }
     }
 
@@ -489,6 +501,8 @@ final class PreferencesModel: ThemeProvider {
             notifyMemoryHigh: notifyMemoryHigh,
             memoryThreshold: memoryThreshold,
             memorySustainedDuration: memorySustainedDuration,
+            notifyBluetoothBatteryLow: notifyBluetoothBatteryLow,
+            bluetoothBatteryThreshold: bluetoothBatteryThreshold,
             widgetLayout: layout,
             widgetSettings: widgetSettings
         )
@@ -533,6 +547,8 @@ final class PreferencesModel: ThemeProvider {
             notifyMemoryHigh = s.notifyMemoryHigh
             memoryThreshold = s.memoryThreshold
             memorySustainedDuration = s.memorySustainedDuration
+            notifyBluetoothBatteryLow = s.notifyBluetoothBatteryLow
+            bluetoothBatteryThreshold = s.bluetoothBatteryThreshold
         }
     }
 
@@ -606,6 +622,8 @@ extension PreferencesModel {
         static let notifyMemoryHigh: Bool = false
         static let memoryThreshold: Double = 90.0
         static let memorySustainedDuration: Double = 5.0
+        static let notifyBluetoothBatteryLow: Bool = false
+        static let bluetoothBatteryThreshold: Double = 20.0
 
         /// Developer
         static let devModeEnabled: Bool = false

--- a/Sources/StatusBar/Preferences/PresetStore.swift
+++ b/Sources/StatusBar/Preferences/PresetStore.swift
@@ -55,6 +55,8 @@ struct PresetSnapshot: Codable {
     var notifyMemoryHigh: Bool
     var memoryThreshold: Double
     var memorySustainedDuration: Double
+    var notifyBluetoothBatteryLow: Bool
+    var bluetoothBatteryThreshold: Double
 
     /// Widget Layout
     var widgetLayout: [WidgetLayoutEntry]
@@ -78,6 +80,8 @@ struct PresetSnapshot: Codable {
         notifyBatteryLow: Bool, batteryThreshold: Double,
         notifyCPUHigh: Bool, cpuThreshold: Double, cpuSustainedDuration: Double,
         notifyMemoryHigh: Bool, memoryThreshold: Double, memorySustainedDuration: Double,
+        notifyBluetoothBatteryLow: Bool = PreferencesModel.Defaults.notifyBluetoothBatteryLow,
+        bluetoothBatteryThreshold: Double = PreferencesModel.Defaults.bluetoothBatteryThreshold,
         widgetLayout: [WidgetLayoutEntry],
         widgetSettings: [String: [String: ConfigValue]]
     ) {
@@ -118,6 +122,8 @@ struct PresetSnapshot: Codable {
         self.notifyMemoryHigh = notifyMemoryHigh
         self.memoryThreshold = memoryThreshold
         self.memorySustainedDuration = memorySustainedDuration
+        self.notifyBluetoothBatteryLow = notifyBluetoothBatteryLow
+        self.bluetoothBatteryThreshold = bluetoothBatteryThreshold
         self.widgetLayout = widgetLayout
         self.widgetSettings = widgetSettings
     }
@@ -169,6 +175,12 @@ struct PresetSnapshot: Codable {
         memorySustainedDuration = try c.decodeIfPresent(
             Double.self, forKey: .memorySustainedDuration
         ) ?? d.memorySustainedDuration
+        notifyBluetoothBatteryLow = try c.decodeIfPresent(
+            Bool.self, forKey: .notifyBluetoothBatteryLow
+        ) ?? d.notifyBluetoothBatteryLow
+        bluetoothBatteryThreshold = try c.decodeIfPresent(
+            Double.self, forKey: .bluetoothBatteryThreshold
+        ) ?? d.bluetoothBatteryThreshold
         widgetSettings = try c.decodeIfPresent([String: [String: ConfigValue]].self, forKey: .widgetSettings) ?? [:]
     }
 }

--- a/Sources/StatusBar/Preferences/Sections/WidgetSettingsSheet.swift
+++ b/Sources/StatusBar/Preferences/Sections/WidgetSettingsSheet.swift
@@ -252,6 +252,33 @@ private struct EventNotifyMinutesEditor: View {
     }
 }
 
+// MARK: - BluetoothWidgetSettings
+
+struct BluetoothWidgetSettings: View {
+    @Bindable private var prefs = PreferencesModel.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ToastAlertSection(
+                enabled: $prefs.notifyBluetoothBatteryLow,
+                threshold: $prefs.bluetoothBatteryThreshold,
+                thresholdRange: 5 ... 50,
+                thresholdLabel: "Threshold"
+            )
+
+            Text(
+                """
+                Alerts fire once when any reporting device (AirPods L/R, Magic Mouse, etc.) \
+                drops below the threshold. Re-arms when the device charges back above it.
+                """
+            )
+            .font(.system(size: 11))
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
 // MARK: - BatteryWidgetSettings
 
 struct BatteryWidgetSettings: View {

--- a/Sources/StatusBar/Services/BluetoothService.swift
+++ b/Sources/StatusBar/Services/BluetoothService.swift
@@ -3,6 +3,7 @@ import Foundation
 import IOBluetooth
 import IOKit
 import OSLog
+import StatusBarKit
 
 private let logger = Logger(subsystem: "com.statusbar", category: "BluetoothService")
 
@@ -18,11 +19,26 @@ final class BluetoothService: NSObject, @unchecked Sendable, CBCentralManagerDel
     /// Called when Bluetooth authorization changes to `.allowedAlways`.
     var onAuthorized: (() -> Void)?
 
+    /// Called on the main queue after an asynchronous `system_profiler` refresh updates the battery cache.
+    /// Widgets can hook this to re-poll and pick up newly-arrived AirPods battery data.
+    var onBatteryCacheRefreshed: (() -> Void)?
+
     struct BluetoothDevice: Identifiable, Equatable {
         let id: String
         let name: String
         let category: DeviceCategory
+        /// Best-effort primary battery (single-battery device or combined/main for AirPods).
         let batteryLevel: Int?
+        /// AirPods left earbud.
+        let leftBattery: Int?
+        /// AirPods right earbud.
+        let rightBattery: Int?
+        /// AirPods case.
+        let caseBattery: Int?
+
+        var hasAirPodsDetail: Bool {
+            leftBattery != nil || rightBattery != nil || caseBattery != nil
+        }
 
         enum DeviceCategory: String {
             case headphones
@@ -45,6 +61,23 @@ final class BluetoothService: NSObject, @unchecked Sendable, CBCentralManagerDel
         }
     }
 
+    /// Detailed battery decomposition returned by richer sources (IORegistry AirPods keys, `system_profiler`).
+    struct DetailedBattery: Equatable {
+        let main: Int?
+        let left: Int?
+        let right: Int?
+        let caseLevel: Int?
+    }
+
+    /// `system_profiler SPBluetoothDataType` cache. Populated asynchronously because the
+    /// underlying command takes ~1-3s and must never block the main poll.
+    private let cacheLock = NSLock()
+    private var batteryCache: [String: DetailedBattery] = [:]
+    private var cacheTimestamp: Date?
+    private var refreshInFlight = false
+
+    private static let cacheTTL: TimeInterval = 60
+
     /// Enumerate connected Bluetooth devices via IOBluetooth framework + IORegistry battery lookup.
     func poll() -> [BluetoothDevice] {
         // IOBluetoothDevice.pairedDevices() requires TCC Bluetooth permission.
@@ -58,8 +91,10 @@ final class BluetoothService: NSObject, @unchecked Sendable, CBCentralManagerDel
             return []
         }
 
-        let batteryMap = queryBatteryLevels()
-        return queryConnectedDevices(batteryMap: batteryMap)
+        let hidBattery = queryHIDBatteryLevels()
+        let detailed = readCache()
+        maybeKickOffCacheRefresh()
+        return queryConnectedDevices(hidBattery: hidBattery, detailed: detailed)
     }
 
     // MARK: - CBCentralManagerDelegate
@@ -74,7 +109,10 @@ final class BluetoothService: NSObject, @unchecked Sendable, CBCentralManagerDel
 
     // MARK: - Device Enumeration (IOBluetooth)
 
-    private func queryConnectedDevices(batteryMap: [String: Int]) -> [BluetoothDevice] {
+    private func queryConnectedDevices(
+        hidBattery: [String: Int],
+        detailed: [String: DetailedBattery]
+    ) -> [BluetoothDevice] {
         guard let paired = IOBluetoothDevice.pairedDevices() as? [IOBluetoothDevice] else {
             return []
         }
@@ -83,18 +121,25 @@ final class BluetoothService: NSObject, @unchecked Sendable, CBCentralManagerDel
         for device in paired where device.isConnected() {
             let name = device.name ?? "Unknown"
             let address = device.addressString ?? "unknown-\(name.lowercased())"
+            let normalizedAddr = normalizeAddress(address)
             let category = classify(
                 majorClass: UInt32(device.deviceClassMajor),
                 minorClass: UInt32(device.deviceClassMinor),
                 name: name
             )
-            let battery = lookupBattery(address: address, name: name, batteryMap: batteryMap)
+
+            let detail = detailed[normalizedAddr]
+            let hid = hidBattery[normalizedAddr] ?? hidBattery[name.lowercased()]
+            let primary = detail?.main ?? hid
 
             devices.append(BluetoothDevice(
                 id: address,
                 name: name,
                 category: category,
-                batteryLevel: battery
+                batteryLevel: primary,
+                leftBattery: detail?.left,
+                rightBattery: detail?.right,
+                caseBattery: detail?.caseLevel
             ))
         }
 
@@ -145,9 +190,9 @@ final class BluetoothService: NSObject, @unchecked Sendable, CBCentralManagerDel
         return .generic
     }
 
-    // MARK: - Battery (IORegistry)
+    // MARK: - HID Battery (IORegistry, Magic devices)
 
-    private func queryBatteryLevels() -> [String: Int] {
+    private func queryHIDBatteryLevels() -> [String: Int] {
         var result: [String: Int] = [:]
 
         let matching = IOServiceMatching("AppleDeviceManagementHIDEventService")
@@ -182,6 +227,167 @@ final class BluetoothService: NSObject, @unchecked Sendable, CBCentralManagerDel
         return result
     }
 
+    // MARK: - AirPods-style Battery (IORegistry recursive scan)
+
+    /// Walk the entire IORegistry looking for services exposing AirPods-style
+    /// `BatteryPercentLeft/Right/Case` keys. Keyed by the service's `DeviceAddress`.
+    private func queryDetailedBatteriesFromIORegistry() -> [String: DetailedBattery] {
+        var result: [String: DetailedBattery] = [:]
+        var iterator: io_iterator_t = 0
+        let options = IOOptionBits(kIORegistryIterateRecursively)
+        guard IORegistryCreateIterator(kIOMainPortDefault, kIOServicePlane, options, &iterator) == KERN_SUCCESS else {
+            return result
+        }
+        defer { IOObjectRelease(iterator) }
+
+        var entry = IOIteratorNext(iterator)
+        while entry != 0 {
+            defer {
+                IOObjectRelease(entry)
+                entry = IOIteratorNext(iterator)
+            }
+
+            guard let props = serviceProperties(entry) else {
+                continue
+            }
+
+            let left = Self.int(props["BatteryPercentLeft"])
+            let right = Self.int(props["BatteryPercentRight"])
+            let caseLevel = Self.int(props["BatteryPercentCase"])
+            let combined = Self.int(props["BatteryPercentCombined"]) ?? Self.int(props["BatteryPercent"])
+
+            guard left != nil || right != nil || caseLevel != nil || combined != nil else {
+                continue
+            }
+
+            guard let addr = (props["DeviceAddress"] as? String) ?? (props["SerialNumber"] as? String) else {
+                continue
+            }
+
+            result[normalizeAddress(addr)] = DetailedBattery(
+                main: combined,
+                left: left,
+                right: right,
+                caseLevel: caseLevel
+            )
+        }
+
+        return result
+    }
+
+    // MARK: - system_profiler Cache
+
+    private func readCache() -> [String: DetailedBattery] {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        return batteryCache
+    }
+
+    private func maybeKickOffCacheRefresh() {
+        cacheLock.lock()
+        let fresh = cacheTimestamp.map { Date().timeIntervalSince($0) < Self.cacheTTL } ?? false
+        let shouldRefresh = !fresh && !refreshInFlight
+        if shouldRefresh {
+            refreshInFlight = true
+        }
+        cacheLock.unlock()
+
+        guard shouldRefresh else {
+            return
+        }
+        Task.detached(priority: .utility) { [weak self] in
+            await self?.performCacheRefresh()
+        }
+    }
+
+    private func performCacheRefresh() async {
+        // IORegistry walk is a full-tree recursive enumeration — run it here on
+        // the background queue alongside `system_profiler` so neither touches
+        // the main thread during `poll()`.
+        let fromIOReg = queryDetailedBatteriesFromIORegistry()
+        let fromSP = await Self.fetchSystemProfilerBatteries()
+
+        // IORegistry is fresher than the periodic `system_profiler` snapshot; prefer it.
+        let merged = fromSP.merging(fromIOReg) { _, ioreg in ioreg }
+
+        cacheLock.withLock {
+            batteryCache = merged
+            cacheTimestamp = Date()
+            refreshInFlight = false
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.onBatteryCacheRefreshed?()
+        }
+    }
+
+    private static func fetchSystemProfilerBatteries() async -> [String: DetailedBattery] {
+        do {
+            let result = try await ShellCommand.runWithResult(
+                "/usr/sbin/system_profiler",
+                arguments: ["SPBluetoothDataType", "-json", "-timeout", "3"],
+                timeout: 5
+            )
+            return parseSystemProfilerJSON(Data(result.stdout.utf8))
+        } catch {
+            logger.debug("system_profiler failed: \(error.localizedDescription)")
+            return [:]
+        }
+    }
+
+    /// Parse `system_profiler SPBluetoothDataType -json` output into a map of device-address → battery.
+    /// Format has shifted across macOS versions; this uses a defensive recursive walk.
+    /// Exposed `internal` for unit testing.
+    static func parseSystemProfilerJSON(_ data: Data?) -> [String: DetailedBattery] {
+        guard let data,
+              let obj = try? JSONSerialization.jsonObject(with: data)
+        else {
+            return [:]
+        }
+        var result: [String: DetailedBattery] = [:]
+        walk(obj) { dict in
+            guard let addr = dict["device_address"] as? String else {
+                return
+            }
+            let main = parsePercent(dict["device_batteryLevelMain"])
+            let left = parsePercent(dict["device_batteryLevelLeft"])
+            let right = parsePercent(dict["device_batteryLevelRight"])
+            let caseLevel = parsePercent(dict["device_batteryLevelCase"])
+            guard main != nil || left != nil || right != nil || caseLevel != nil else {
+                return
+            }
+            let key = normalize(addr)
+            result[key] = DetailedBattery(main: main, left: left, right: right, caseLevel: caseLevel)
+        }
+        return result
+    }
+
+    private static func walk(_ obj: Any, _ visit: ([String: Any]) -> Void) {
+        if let dict = obj as? [String: Any] {
+            visit(dict)
+            for (_, value) in dict {
+                walk(value, visit)
+            }
+        } else if let arr = obj as? [Any] {
+            for value in arr {
+                walk(value, visit)
+            }
+        }
+    }
+
+    private static func parsePercent(_ raw: Any?) -> Int? {
+        if let number = raw as? NSNumber {
+            return number.intValue
+        }
+        guard let string = raw as? String else {
+            return nil
+        }
+        let trimmed = string.trimmingCharacters(in: CharacterSet(charactersIn: "% "))
+        return Int(trimmed)
+    }
+
+    // MARK: - Helpers
+
     private func serviceProperties(_ service: io_object_t) -> [String: Any]? {
         var propsRef: Unmanaged<CFMutableDictionary>?
         guard IORegistryEntryCreateCFProperties(service, &propsRef, kCFAllocatorDefault, 0) == KERN_SUCCESS,
@@ -192,17 +398,15 @@ final class BluetoothService: NSObject, @unchecked Sendable, CBCentralManagerDel
         return cfDict as? [String: Any]
     }
 
-    private func lookupBattery(address: String, name: String, batteryMap: [String: Int]) -> Int? {
-        if let level = batteryMap[normalizeAddress(address)] {
-            return level
-        }
-        if let level = batteryMap[name.lowercased()] {
-            return level
-        }
-        return nil
+    private static func int(_ any: Any?) -> Int? {
+        (any as? NSNumber)?.intValue
     }
 
     private func normalizeAddress(_ address: String) -> String {
+        Self.normalize(address)
+    }
+
+    fileprivate static func normalize(_ address: String) -> String {
         address.lowercased().replacingOccurrences(of: "-", with: ":").trimmingCharacters(in: .whitespaces)
     }
 }

--- a/Sources/StatusBar/Widgets/BluetoothBatteryAlertTracker.swift
+++ b/Sources/StatusBar/Widgets/BluetoothBatteryAlertTracker.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+// MARK: - BluetoothBatteryAlertTracker
+
+/// Pure threshold state machine for the Bluetooth low-battery notification.
+/// Call `evaluate(...)` with the current device list and user preferences; it
+/// returns the alerts that should fire this tick and mutates internal state so
+/// the next call suppresses repeats until the reading rises back above the
+/// threshold. Side effects (toasts, event emission) live outside so the state
+/// machine stays unit-testable with no app singletons involved.
+///
+/// State key layout:
+///   - Single-battery devices: `<device.id>`
+///   - AirPods components: `<device.id>:left` and `<device.id>:right`
+struct BluetoothBatteryAlertTracker {
+    struct Alert: Equatable {
+        let deviceID: String
+        let deviceName: String
+        let component: String?
+        let percent: Int
+    }
+
+    private var notifiedKeys: Set<String> = []
+
+    mutating func evaluate(
+        devices: [BluetoothService.BluetoothDevice],
+        enabled: Bool,
+        threshold: Int
+    ) -> [Alert] {
+        guard enabled else {
+            // When the toggle goes off, forget history so re-enabling re-notifies.
+            notifiedKeys.removeAll(keepingCapacity: true)
+            return []
+        }
+
+        var alerts: [Alert] = []
+        var stillTrackable: Set<String> = []
+
+        for device in devices {
+            if device.hasAirPodsDetail {
+                for (component, reading) in [("left", device.leftBattery), ("right", device.rightBattery)] {
+                    guard let reading else {
+                        continue
+                    }
+                    if let alert = record(
+                        device: device,
+                        component: component,
+                        percent: reading,
+                        threshold: threshold,
+                        tracked: &stillTrackable
+                    ) {
+                        alerts.append(alert)
+                    }
+                }
+            } else if let battery = device.batteryLevel {
+                if let alert = record(
+                    device: device,
+                    component: nil,
+                    percent: battery,
+                    threshold: threshold,
+                    tracked: &stillTrackable
+                ) {
+                    alerts.append(alert)
+                }
+            }
+        }
+
+        // Drop any keys that are no longer reporting — disconnected devices or
+        // a component that stopped sending a reading. Without this the tracker
+        // would silently suppress a re-connection at a low level.
+        notifiedKeys.formIntersection(stillTrackable)
+
+        return alerts
+    }
+
+    private mutating func record(
+        device: BluetoothService.BluetoothDevice,
+        component: String?,
+        percent: Int,
+        threshold: Int,
+        tracked: inout Set<String>
+    ) -> Alert? {
+        let key = component.map { "\(device.id):\($0)" } ?? device.id
+        tracked.insert(key)
+        if percent <= threshold {
+            guard notifiedKeys.insert(key).inserted else {
+                return nil
+            }
+            return Alert(
+                deviceID: device.id,
+                deviceName: device.name,
+                component: component,
+                percent: percent
+            )
+        }
+        notifiedKeys.remove(key)
+        return nil
+    }
+}

--- a/Sources/StatusBar/Widgets/BluetoothWidget.swift
+++ b/Sources/StatusBar/Widgets/BluetoothWidget.swift
@@ -8,15 +8,17 @@ enum BluetoothEvent {
     static let devicesChanged = "bluetooth_devices_changed"
     static let deviceConnected = "bluetooth_device_connected"
     static let deviceDisconnected = "bluetooth_device_disconnected"
+    static let batteryLow = "bluetooth_battery_low"
 }
 
 extension IPCEventEnvelope {
-    static func bluetoothDevicesChanged(connectedCount: Int, deviceNames: [String]) -> Self {
+    static func bluetoothDevicesChanged(devices: [BluetoothService.BluetoothDevice]) -> Self {
         IPCEventEnvelope(
             event: BluetoothEvent.devicesChanged,
             payload: .object([
-                "connectedCount": .number(Double(connectedCount)),
-                "deviceNames": .array(deviceNames.map { .string($0) }),
+                "connectedCount": .number(Double(devices.count)),
+                "deviceNames": .array(devices.map { .string($0.name) }),
+                "devices": .array(devices.map(deviceInfoPayload)),
             ])
         )
     }
@@ -37,6 +39,40 @@ extension IPCEventEnvelope {
             payload: .object(["name": .string(name)])
         )
     }
+
+    static func bluetoothBatteryLow(deviceName: String, component: String?, percent: Int, threshold: Int) -> Self {
+        var payload: [String: JSONValue] = [
+            "deviceName": .string(deviceName),
+            "percent": .number(Double(percent)),
+            "threshold": .number(Double(threshold)),
+        ]
+        if let component {
+            payload["component"] = .string(component)
+        } else {
+            payload["component"] = .null
+        }
+        return IPCEventEnvelope(event: BluetoothEvent.batteryLow, payload: .object(payload))
+    }
+
+    private static func deviceInfoPayload(_ device: BluetoothService.BluetoothDevice) -> JSONValue {
+        var obj: [String: JSONValue] = [
+            "name": .string(device.name),
+            "category": .string(device.category.rawValue),
+        ]
+        if let b = device.batteryLevel {
+            obj["battery"] = .number(Double(b))
+        }
+        if let l = device.leftBattery {
+            obj["batteryLeft"] = .number(Double(l))
+        }
+        if let r = device.rightBattery {
+            obj["batteryRight"] = .number(Double(r))
+        }
+        if let c = device.caseBattery {
+            obj["batteryCase"] = .number(Double(c))
+        }
+        return .object(obj)
+    }
 }
 
 // MARK: - BluetoothWidget
@@ -56,6 +92,8 @@ final class BluetoothWidget: StatusBarWidget, EventEmitting {
     private let service = BluetoothService()
     private var popupPanel: PopupPanel?
 
+    private var alertTracker = BluetoothBatteryAlertTracker()
+
     private var connectedCount: Int {
         devices.count
     }
@@ -63,42 +101,18 @@ final class BluetoothWidget: StatusBarWidget, EventEmitting {
     func start() {
         service.onAuthorized = { [weak self] in
             DispatchQueue.main.async {
-                self?.devices = self?.service.poll() ?? []
+                self?.refresh()
             }
         }
-        devices = service.poll()
+        service.onBatteryCacheRefreshed = { [weak self] in
+            self?.refresh()
+        }
+        refresh()
         let interval = updateInterval ?? 10
         timer = Timer.publish(every: interval, tolerance: interval * 0.1, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
-                guard let self else {
-                    return
-                }
-                let updated = service.poll()
-                guard updated != devices else {
-                    return
-                }
-                let oldIDs = Set(devices.map(\.id))
-                let newIDs = Set(updated.map(\.id))
-                let added = updated.filter { !oldIDs.contains($0.id) }
-                let removed = devices.filter { !newIDs.contains($0.id) }
-                devices = updated
-                emit(.bluetoothDevicesChanged(
-                    connectedCount: updated.count,
-                    deviceNames: updated.map(\.name)
-                ))
-                for device in added {
-                    emit(.bluetoothDeviceConnected(
-                        name: device.name,
-                        category: device.category.rawValue
-                    ))
-                }
-                for device in removed {
-                    emit(.bluetoothDeviceDisconnected(name: device.name))
-                }
-                if popupPanel?.isVisible == true {
-                    refreshPopup()
-                }
+                self?.refresh()
             }
     }
 
@@ -128,6 +142,86 @@ final class BluetoothWidget: StatusBarWidget, EventEmitting {
         .accessibilityValue(connectedCount > 0 ? "\(connectedCount) devices connected" : "No devices")
     }
 
+    func settingsBody() -> some View {
+        BluetoothWidgetSettings()
+    }
+
+    // MARK: - Current devices (exposed for IPC runtime state)
+
+    var currentDevices: [BluetoothService.BluetoothDevice] {
+        devices
+    }
+
+    // MARK: - Refresh
+
+    private func refresh() {
+        let updated = service.poll()
+        let dataChanged = updated != devices
+        guard dataChanged else {
+            fireBatteryAlerts(for: updated)
+            return
+        }
+
+        let oldIDs = Set(devices.map(\.id))
+        let newIDs = Set(updated.map(\.id))
+        let topologyChanged = oldIDs != newIDs
+        let added = updated.filter { !oldIDs.contains($0.id) }
+        let removed = devices.filter { !newIDs.contains($0.id) }
+        devices = updated
+
+        // `bluetooth_devices_changed` is a topology-transition event — don't
+        // fire it for battery-only fluctuations or the payload hits subscribers
+        // every 10s while AirPods are in use. Battery changes are surfaced via
+        // `bluetooth_battery_low` (threshold) instead.
+        if topologyChanged {
+            emit(.bluetoothDevicesChanged(devices: updated))
+            for device in added {
+                emit(.bluetoothDeviceConnected(
+                    name: device.name,
+                    category: device.category.rawValue
+                ))
+            }
+            for device in removed {
+                emit(.bluetoothDeviceDisconnected(name: device.name))
+            }
+        }
+        fireBatteryAlerts(for: updated)
+        if popupPanel?.isVisible == true {
+            refreshPopup()
+        }
+    }
+
+    // MARK: - Low-battery Detection
+
+    /// Run the alert tracker against the latest readings and dispatch any
+    /// transitions as toasts + IPC events. The tracker is pure; side effects
+    /// live here so they stay injectable-free and isolated from the logic.
+    private func fireBatteryAlerts(for devices: [BluetoothService.BluetoothDevice]) {
+        let prefs = PreferencesModel.shared
+        let threshold = Int(prefs.bluetoothBatteryThreshold)
+        let alerts = alertTracker.evaluate(
+            devices: devices,
+            enabled: prefs.notifyBluetoothBatteryLow,
+            threshold: threshold
+        )
+        for alert in alerts {
+            let title = alert.component.map { "\(alert.deviceName) (\($0)) Low" } ?? "\(alert.deviceName) Low Battery"
+            ToastManager.shared.post(ToastRequest(
+                title: title,
+                message: "Battery is at \(alert.percent)%",
+                level: .warning
+            ))
+            emit(.bluetoothBatteryLow(
+                deviceName: alert.deviceName,
+                component: alert.component,
+                percent: alert.percent,
+                threshold: threshold
+            ))
+        }
+    }
+
+    // MARK: - Popup
+
     private func togglePopup() {
         if popupPanel?.isVisible == true {
             popupPanel?.hidePopup()
@@ -150,14 +244,15 @@ final class BluetoothWidget: StatusBarWidget, EventEmitting {
     }
 
     private func refreshPopup() {
-        guard let panel = popupPanel, panel.isVisible,
-              let (barFrame, screen) = PopupPanel.barTriggerFrame()
-        else {
+        guard let panel = popupPanel, panel.isVisible else {
             return
         }
-
-        let content = BluetoothPopupContent(devices: devices)
-        panel.showPopup(relativeTo: barFrame, on: screen, content: content)
+        // Update in place without re-reading the current mouse position —
+        // the async `system_profiler` callback fires seconds after the user
+        // clicked, so recomputing `barTriggerFrame()` here would snap the
+        // popup to wherever the cursor has since moved.
+        panel.updateContent(BluetoothPopupContent(devices: devices))
+        panel.resizeToFitContent()
     }
 }
 
@@ -175,29 +270,7 @@ private struct BluetoothPopupContent: View {
             } else {
                 VStack(spacing: 2) {
                     ForEach(devices) { device in
-                        HStack(spacing: 10) {
-                            Image(systemName: device.category.iconName)
-                                .font(.system(size: 13, weight: .medium))
-                                .foregroundStyle(Theme.accentBlue)
-                                .frame(width: 22, alignment: .center)
-                                .symbolRenderingMode(.hierarchical)
-
-                            Text(device.name)
-                                .font(.system(size: 13, weight: .regular, design: .rounded))
-                                .foregroundStyle(.primary)
-                                .lineLimit(1)
-
-                            Spacer()
-
-                            if let battery = device.batteryLevel {
-                                PopupStatusBadge(
-                                    "\(battery)%",
-                                    color: batteryColor(battery)
-                                )
-                            }
-                        }
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 7)
+                        deviceRow(device)
                     }
                 }
                 .padding(.horizontal, 6)
@@ -205,6 +278,51 @@ private struct BluetoothPopupContent: View {
         }
         .padding(.bottom, 8)
         .frame(width: 280)
+    }
+
+    private func deviceRow(_ device: BluetoothService.BluetoothDevice) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: device.category.iconName)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Theme.accentBlue)
+                .frame(width: 22, alignment: .center)
+                .symbolRenderingMode(.hierarchical)
+
+            Text(device.name)
+                .font(.system(size: 13, weight: .regular, design: .rounded))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+
+            Spacer()
+
+            if device.hasAirPodsDetail {
+                airPodsBadges(device)
+            } else if let battery = device.batteryLevel {
+                PopupStatusBadge("\(battery)%", color: batteryColor(battery))
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+    }
+
+    private func airPodsBadges(_ device: BluetoothService.BluetoothDevice) -> some View {
+        HStack(spacing: 4) {
+            componentBadge(label: "L", value: device.leftBattery)
+            componentBadge(label: "R", value: device.rightBattery)
+            componentBadge(label: "C", value: device.caseBattery)
+        }
+    }
+
+    @ViewBuilder
+    private func componentBadge(label: String, value: Int?) -> some View {
+        if let value {
+            HStack(spacing: 2) {
+                Text(label)
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.tertiary)
+                PopupStatusBadge("\(value)%", color: batteryColor(value))
+            }
+        }
     }
 
     private func batteryColor(_ level: Int) -> Color {

--- a/Tests/StatusBarTests/BluetoothServiceTests.swift
+++ b/Tests/StatusBarTests/BluetoothServiceTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+@testable import StatusBar
+import Testing
+
+// MARK: - BluetoothServiceSystemProfilerParsingTests
+
+struct BluetoothServiceSystemProfilerParsingTests {
+
+    @Test("Returns empty map for nil input")
+    func nilInput() {
+        #expect(BluetoothService.parseSystemProfilerJSON(nil).isEmpty)
+    }
+
+    @Test("Returns empty map for malformed JSON")
+    func malformed() {
+        let data = Data("{not json}".utf8)
+        #expect(BluetoothService.parseSystemProfilerJSON(data).isEmpty)
+    }
+
+    @Test("Parses AirPods L/R/Case/Main from nested structure")
+    func airPodsNested() throws {
+        let json = """
+        {
+          "SPBluetoothDataType": [{
+            "device_connected": [{
+              "AirPods Pro": {
+                "device_address": "AA:BB:CC:DD:EE:FF",
+                "device_batteryLevelMain": "75%",
+                "device_batteryLevelLeft": "70%",
+                "device_batteryLevelRight": "65%",
+                "device_batteryLevelCase": "100%",
+                "device_minorType": "Headphones"
+              }
+            }]
+          }]
+        }
+        """
+        let result = BluetoothService.parseSystemProfilerJSON(Data(json.utf8))
+        let battery = try #require(result["aa:bb:cc:dd:ee:ff"])
+        #expect(battery.main == 75)
+        #expect(battery.left == 70)
+        #expect(battery.right == 65)
+        #expect(battery.caseLevel == 100)
+    }
+
+    @Test("Parses numeric battery values without percent suffix")
+    func numericBattery() throws {
+        let json = """
+        {
+          "devices": [{
+            "Magic Mouse": {
+              "device_address": "12:34:56:78:9A:BC",
+              "device_batteryLevelMain": 55
+            }
+          }]
+        }
+        """
+        let result = BluetoothService.parseSystemProfilerJSON(Data(json.utf8))
+        let battery = try #require(result["12:34:56:78:9a:bc"])
+        #expect(battery.main == 55)
+        #expect(battery.left == nil)
+    }
+
+    @Test("Skips entries without any battery fields")
+    func skipsUnbatteried() {
+        let json = """
+        {
+          "device_title": {
+            "Bluetooth Keyboard": {
+              "device_address": "11:22:33:44:55:66"
+            }
+          }
+        }
+        """
+        let result = BluetoothService.parseSystemProfilerJSON(Data(json.utf8))
+        #expect(result.isEmpty)
+    }
+
+    @Test("Address is lowercased for stable lookup")
+    func normalizesAddressCase() {
+        let json = """
+        {
+          "d": {
+            "AirPods": {
+              "device_address": "AB:CD:EF:01:02:03",
+              "device_batteryLevelLeft": "50%"
+            }
+          }
+        }
+        """
+        let result = BluetoothService.parseSystemProfilerJSON(Data(json.utf8))
+        #expect(result["ab:cd:ef:01:02:03"]?.left == 50)
+        #expect(result["AB:CD:EF:01:02:03"] == nil)
+    }
+}
+
+// MARK: - BluetoothBatteryAlertTrackerTests
+
+struct BluetoothBatteryAlertTrackerTests {
+
+    private func airPods(
+        id: String = "airpods", left: Int?, right: Int?, caseLevel: Int? = nil
+    ) -> BluetoothService.BluetoothDevice {
+        BluetoothService.BluetoothDevice(
+            id: id,
+            name: "AirPods Pro",
+            category: .headphones,
+            batteryLevel: nil,
+            leftBattery: left,
+            rightBattery: right,
+            caseBattery: caseLevel
+        )
+    }
+
+    private func mouse(id: String = "mouse", battery: Int?) -> BluetoothService.BluetoothDevice {
+        BluetoothService.BluetoothDevice(
+            id: id,
+            name: "Magic Mouse",
+            category: .mouse,
+            batteryLevel: battery,
+            leftBattery: nil,
+            rightBattery: nil,
+            caseBattery: nil
+        )
+    }
+
+    @Test("Returns no alerts when disabled, even below threshold")
+    func disabled() {
+        var tracker = BluetoothBatteryAlertTracker()
+        let alerts = tracker.evaluate(devices: [mouse(battery: 5)], enabled: false, threshold: 20)
+        #expect(alerts.isEmpty)
+    }
+
+    @Test("Fires once when crossing threshold, suppresses on next tick")
+    func fireOnceOnCrossing() {
+        var tracker = BluetoothBatteryAlertTracker()
+        let first = tracker.evaluate(devices: [mouse(battery: 15)], enabled: true, threshold: 20)
+        #expect(first.count == 1)
+        #expect(first.first?.deviceName == "Magic Mouse")
+        #expect(first.first?.percent == 15)
+        #expect(first.first?.component == nil)
+
+        let second = tracker.evaluate(devices: [mouse(battery: 14)], enabled: true, threshold: 20)
+        #expect(second.isEmpty)
+    }
+
+    @Test("Re-arms and re-fires after battery rises above threshold and drops again")
+    func reArmsAfterRise() {
+        var tracker = BluetoothBatteryAlertTracker()
+        _ = tracker.evaluate(devices: [mouse(battery: 15)], enabled: true, threshold: 20)
+
+        let above = tracker.evaluate(devices: [mouse(battery: 60)], enabled: true, threshold: 20)
+        #expect(above.isEmpty)
+
+        let third = tracker.evaluate(devices: [mouse(battery: 10)], enabled: true, threshold: 20)
+        #expect(third.count == 1)
+        #expect(third.first?.percent == 10)
+    }
+
+    @Test("AirPods L and R tracked independently; Case excluded")
+    func airPodsPerComponent() {
+        var tracker = BluetoothBatteryAlertTracker()
+        let alerts = tracker.evaluate(
+            devices: [airPods(left: 15, right: 55, caseLevel: 5)],
+            enabled: true, threshold: 20
+        )
+        #expect(alerts.count == 1)
+        #expect(alerts.first?.component == "left")
+        #expect(alerts.first?.percent == 15)
+
+        let next = tracker.evaluate(
+            devices: [airPods(left: 15, right: 18, caseLevel: 5)],
+            enabled: true, threshold: 20
+        )
+        #expect(next.count == 1)
+        #expect(next.first?.component == "right")
+    }
+
+    @Test("Disconnecting and reconnecting at a low level re-fires")
+    func disconnectReconnect() {
+        var tracker = BluetoothBatteryAlertTracker()
+        _ = tracker.evaluate(devices: [mouse(battery: 10)], enabled: true, threshold: 20)
+
+        let empty = tracker.evaluate(devices: [], enabled: true, threshold: 20)
+        #expect(empty.isEmpty)
+
+        let alerts = tracker.evaluate(devices: [mouse(battery: 10)], enabled: true, threshold: 20)
+        #expect(alerts.count == 1)
+    }
+
+    @Test("Toggling off clears history so next enable re-notifies")
+    func toggleOffClearsHistory() {
+        var tracker = BluetoothBatteryAlertTracker()
+        _ = tracker.evaluate(devices: [mouse(battery: 10)], enabled: true, threshold: 20)
+
+        let off = tracker.evaluate(devices: [mouse(battery: 10)], enabled: false, threshold: 20)
+        #expect(off.isEmpty)
+
+        let reEnabled = tracker.evaluate(devices: [mouse(battery: 10)], enabled: true, threshold: 20)
+        #expect(reEnabled.count == 1)
+    }
+
+    @Test("Exact threshold value triggers (<=)")
+    func exactThreshold() {
+        var tracker = BluetoothBatteryAlertTracker()
+        let alerts = tracker.evaluate(devices: [mouse(battery: 20)], enabled: true, threshold: 20)
+        #expect(alerts.count == 1)
+    }
+
+    @Test("Device without any battery reading produces no alerts")
+    func noBatteryNoAlert() {
+        var tracker = BluetoothBatteryAlertTracker()
+        let alerts = tracker.evaluate(devices: [mouse(battery: nil)], enabled: true, threshold: 20)
+        #expect(alerts.isEmpty)
+    }
+}
+
+// MARK: - BluetoothDeviceShapeTests
+
+struct BluetoothDeviceShapeTests {
+
+    @Test("hasAirPodsDetail true when any component populated")
+    func detailTrue() {
+        let device = BluetoothService.BluetoothDevice(
+            id: "x", name: "AirPods Pro", category: .headphones,
+            batteryLevel: 75, leftBattery: 70, rightBattery: nil, caseBattery: nil
+        )
+        #expect(device.hasAirPodsDetail)
+    }
+
+    @Test("hasAirPodsDetail false when only single battery present")
+    func detailFalse() {
+        let device = BluetoothService.BluetoothDevice(
+            id: "x", name: "Magic Mouse", category: .mouse,
+            batteryLevel: 50, leftBattery: nil, rightBattery: nil, caseBattery: nil
+        )
+        #expect(!device.hasAirPodsDetail)
+    }
+}


### PR DESCRIPTION
## Summary
Expose per-device Bluetooth battery in the Bluetooth widget popup — including AirPods L / R / Case — and add an optional toast + IPC event when any reporting device drops below the configured threshold.

## Changes

**Battery extraction (`Services/BluetoothService.swift`)**
- Recursive IORegistry walk for AirPods-style `BatteryPercentLeft/Right/Case` keys
- `system_profiler SPBluetoothDataType -json` as fallback, wrapped by existing `ShellCommand.runWithResult`
- Results merged into a 60s-TTL cache populated on a background task so `poll()` no longer runs IORegistry traversal or subprocess work on the main thread

**Widget (`Widgets/BluetoothWidget.swift` + new `BluetoothBatteryAlertTracker.swift`)**
- Popup shows AirPods L / R / Case as compact badges; single-battery devices still render one badge
- Pure threshold state machine (`BluetoothBatteryAlertTracker`) — notify once on crossing, re-arm when the reading rises back, clear on disconnect
- `bluetooth_devices_changed` now only fires on topology transitions; per-device battery info is carried in the payload but won't spam subscribers on 1 % fluctuations
- Popup refresh uses `updateContent` + `resizeToFitContent` so the async cache callback can't reposition the popup to follow the cursor

**Preferences / config**
- `notifications.bluetoothBatteryLow` + `notifications.bluetoothBatteryThreshold` (default 20 %) added to YAML, `PreferencesModel`, `PresetSnapshot`
- YAML decode uses `decodeIfPresent` so existing configs upgrade without a wipe
- New settings section under the Bluetooth widget's gear icon (`BluetoothWidgetSettings`)

**IPC**
- New event `bluetooth_battery_low` (`deviceName`, `component`, `percent`, `threshold`)
- `sbar get bluetooth --json` exposes live connected-device state via `state.deviceCount` / `state.devices` (JSON-encoded)
- `sbar set bluetooth state.*` is rejected with a clear error so runtime keys never pollute the config file

## Notes
- **AirPods key names are not empirically verified on my current machine** (no AirPods paired). The IORegistry keys (`BatteryPercentLeft/Right/Case`) and `system_profiler` keys (`device_batteryLevelLeft/Right/Case/Main`) follow the convention used by AirBuddy / OpenPods and similar open-source tools. If the popup shows no battery on AirPods, run `ioreg -r -l -w 80 | rg -i batterypercent` and `system_profiler SPBluetoothDataType -json | jq '..|objects|select(.device_address?)'` to confirm the actual key names on macOS 26.
- Case battery is intentionally excluded from alerts — users often leave the case uncharged and firing on that would be too noisy. L / R earbuds only.
- `BluetoothWidgetLocator` is a local weak-ref indirection so `GetWidgetCommandHandler` can read the widget's device list without pulling the whole widget into the IPC layer. If we grow more widgets needing runtime state, this is a candidate to generalise.

## Test plan
- [x] `swift test` (201 tests, including 16 new: parser + alert-tracker + device shape)
- [x] `make run-dev` — app launches, `sbar get bluetooth --json` returns `state.*` keys
- [x] `sbar set bluetooth state.deviceCount=5` → rejected with clear error
- [ ] Manual verification with AirPods connected: popup shows L/R/Case, low-battery toast fires below threshold