### PR TITLE
fix: restore bar and toast visibility in screen capture

### DIFF
--- a/Sources/StatusBar/Core/BarWindow.swift
+++ b/Sources/StatusBar/Core/BarWindow.swift
@@ -25,7 +25,6 @@ final class BarWindow: NSPanel {
         hidesOnDeactivate = false
         backgroundColor = .clear
         isOpaque = false
-        sharingType = .none
         titleVisibility = .hidden
         titlebarAppearsTransparent = true
 

--- a/Sources/StatusBar/Toast/ToastTrayPanel.swift
+++ b/Sources/StatusBar/Toast/ToastTrayPanel.swift
@@ -21,7 +21,6 @@ final class ToastTrayPanel: NSPanel {
         hidesOnDeactivate = false
         backgroundColor = .clear
         isOpaque = false
-        sharingType = .none
         titleVisibility = .hidden
         titlebarAppearsTransparent = true
     }


### PR DESCRIPTION
## Summary

The status bar and toast panels stopped appearing in screenshots and screen sharing after #105. This restores their visibility without regressing the HDCP protection fix.

## Changes

- Remove `sharingType = .none` from `BarWindow` (Sources/StatusBar/Core/BarWindow.swift) and `ToastTrayPanel` (Sources/StatusBar/Toast/ToastTrayPanel.swift).

## Notes

`sharingType = .none` was added in #105 as a defensive measure alongside the real HDCP fix (switching `FullscreenDetector` from `CGWindowListCopyWindowInfo` to `CGSCopyManagedDisplaySpaces`). The HDCP disabling was caused by requiring Screen Recording permission, and that is already resolved by the CGS API switch. Excluding our own overlay panels from screen capture is not required to keep HDCP intact, so removing it is safe and restores the expected screenshot/screen-share behavior.