### PR TITLE
fix: tighten plugin lifecycle and battery observer cleanup

### DIFF
--- a/Sources/StatusBar/Plugins/DylibPluginLoader.swift
+++ b/Sources/StatusBar/Plugins/DylibPluginLoader.swift
@@ -249,9 +249,12 @@ final class DylibPluginLoader {
         }
 
         // Cast to C function pointer and call
-        typealias PluginFactory = @convention(c) () -> UnsafeMutableRawPointer
+        typealias PluginFactory = @convention(c) () -> UnsafeMutableRawPointer?
         let factory = unsafeBitCast(sym, to: PluginFactory.self)
-        let rawPtr = factory()
+        guard let rawPtr = factory() else {
+            dlclose(handle)
+            throw PluginLoadError.pluginFactoryFailed
+        }
 
         // Extract PluginBox
         let anyObject = Unmanaged<AnyObject>.fromOpaque(rawPtr).takeRetainedValue()
@@ -288,6 +291,11 @@ final class DylibPluginLoader {
 
         // Skip version compatibility check for dev mode
 
+        // Reject duplicate plugin IDs to avoid leaking dlopen handles across hot-reloads
+        guard loadedHandles[manifest.id] == nil else {
+            throw PluginLoadError.duplicatePluginID(manifest.id)
+        }
+
         // Find the dylib
         let dylibURL = findDylib(in: bundleURL, manifest: manifest)
         guard let dylibURL, FileManager.default.fileExists(atPath: dylibURL.path) else {
@@ -308,9 +316,12 @@ final class DylibPluginLoader {
         }
 
         // Cast to C function pointer and call
-        typealias PluginFactory = @convention(c) () -> UnsafeMutableRawPointer
+        typealias PluginFactory = @convention(c) () -> UnsafeMutableRawPointer?
         let factory = unsafeBitCast(sym, to: PluginFactory.self)
-        let rawPtr = factory()
+        guard let rawPtr = factory() else {
+            dlclose(handle)
+            throw PluginLoadError.pluginFactoryFailed
+        }
 
         // Extract PluginBox
         let anyObject = Unmanaged<AnyObject>.fromOpaque(rawPtr).takeRetainedValue()

--- a/Sources/StatusBar/Plugins/DylibPluginLoader.swift
+++ b/Sources/StatusBar/Plugins/DylibPluginLoader.swift
@@ -351,12 +351,11 @@ final class DylibPluginLoader {
     // MARK: - Unload
 
     /// Mark a plugin for removal. Stops widgets immediately, but full cleanup requires restart.
-    func markForRemoval(pluginID: String) {
-        if let plugin = loadedPlugins[pluginID] {
-            for widget in plugin.widgets {
-                widget.stop()
-            }
-        }
+    func markForRemoval(pluginID: String, from registry: WidgetRegistry) {
+        // Unregister widgets BEFORE dlclose so the registry does not retain
+        // AnyStatusBarWidget wrappers whose class metadata lives in the unloaded dylib.
+        let oldWidgetIDs = Set(widgetIDs(for: pluginID))
+        registry.unregisterWidgets(ids: oldWidgetIDs, preserveLayout: false)
         eventRouter.unregisterPlugin(pluginID)
         teardown(pluginID: pluginID)
     }

--- a/Sources/StatusBar/Preferences/Sections/PluginsSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/PluginsSection.swift
@@ -458,7 +458,7 @@ extension PluginsSection {
 
     private func uninstallPlugin(id: String) {
         do {
-            DylibPluginLoader.shared.markForRemoval(pluginID: id)
+            DylibPluginLoader.shared.markForRemoval(pluginID: id, from: WidgetRegistry.shared)
             try GitHubPluginInstaller.shared.uninstall(pluginID: id)
             needsRestart = true
         } catch {

--- a/Sources/StatusBar/Widgets/BatteryWidget.swift
+++ b/Sources/StatusBar/Widgets/BatteryWidget.swift
@@ -91,9 +91,14 @@ final class BatteryWidget: StatusBarWidget, EventEmitting {
     private var isCharging = false
     private var hasBattery = true
     private var showPercentage = true
+    private var observerToken: BatteryService.ObserverToken?
+
     func start() {
+        guard observerToken == nil else {
+            return
+        }
         showPercentage = BatterySettings.shared.showPercentage
-        BatteryService.shared.addObserver { [weak self] pct, charging, battery in
+        observerToken = BatteryService.shared.addObserver { [weak self] pct, charging, battery in
             guard let self else {
                 return
             }
@@ -113,7 +118,10 @@ final class BatteryWidget: StatusBarWidget, EventEmitting {
     }
 
     func stop() {
-        // Singleton is shared; stop is managed centrally
+        if let token = observerToken {
+            BatteryService.shared.removeObserver(token)
+            observerToken = nil
+        }
     }
 
     var hasSettings: Bool {


### PR DESCRIPTION
## Summary
A multi-agent audit surfaced four P0/P1 stability issues touching plugin loading/removal and battery observation. This PR lands small, targeted fixes for each — one commit per issue (with the two plugin-loader fixes combined since they sit in the same code path).

## Changes

### P0: unregister widgets before `dlclose` in plugin removal
`DylibPluginLoader.markForRemoval` closed the dylib without removing widgets from `WidgetRegistry`, leaving `AnyStatusBarWidget` wrappers whose class metadata lived in the unloaded dylib. `WidgetRegistry.layout` is `@Observable`, so SwiftUI re-renders `BarContentView` on any subsequent state change and calls `body()` / `deinit` on widgets backed by unmapped code — crash. Mirror the existing `reload()` path by calling `unregisterWidgets` before `teardown`.

### P1: remove battery observer on widget stop
`BatteryWidget.stop()` was a no-op. Because `WidgetRegistry.setVisible` calls `start()` each time the widget becomes visible, toggling visibility appended a new observer closure to the shared `BatteryService` every time. The accumulated observers each emitted `battery_changed` IPC events and fired low-battery toasts independently. Capture the `ObserverToken` returned by `addObserver`, call `removeObserver` in `stop()`, and guard `start()` against double registration.

### P1: guard `loadDev` duplicate IDs and null factory returns
- `loadDev` missed the duplicate-ID guard present in `load()`, so clicking "Load" twice on the same dev bundle re-opened the dylib, overwrote `loadedHandles[id]`, and re-registered widgets/event subscriptions. Added the same guard.
- `factory()` was typed as returning a non-optional `UnsafeMutableRawPointer`, but a plugin with a mismatched ABI or a C-side factory can legitimately return null. The previous code fed that null straight into `Unmanaged.fromOpaque`, which crashes. Typed the return as `UnsafeMutableRawPointer?` and throw `pluginFactoryFailed` on null.

## Notes
- Scope kept intentionally small: no refactors, no new abstractions, no churn in neighbouring code.
- All 201 existing tests still pass after each commit.
- Items the audit surfaced but are **not** in this PR: network counter spike on VPN connect, `BluetoothBatteryAlertTracker` tests, `TimeWidget` minute-boundary alignment. Happy to address in follow-ups if desired.