### PR TITLE
fix: harden config loader and add migration-safe decoding

### DIFF
--- a/Sources/StatusBar/Config/ConfigLoader.swift
+++ b/Sources/StatusBar/Config/ConfigLoader.swift
@@ -54,14 +54,49 @@ final class ConfigLoader {
 
     // MARK: - Bootstrap
 
-    /// Call once from `AppDelegate`, before `Theme.configure`.
-    func bootstrap() {
+    /// Outcome of reading (and possibly initializing) the config file on bootstrap.
+    enum BootstrapOutcome {
+        /// Existing file was parsed successfully.
+        case loaded(StatusBarConfig)
+        /// File was absent; defaults were written to disk.
+        case firstLaunch(StatusBarConfig)
+        /// File exists but failed to parse. Disk is left untouched.
+        case parseFailed(Error)
+    }
+
+    /// Pure I/O portion of bootstrap, safe to unit-test against a temp directory.
+    /// Does not touch any shared model state.
+    nonisolated static func performBootstrapLoad(fileURL: URL) -> BootstrapOutcome {
         let fm = FileManager.default
         let dir = fileURL.deletingLastPathComponent()
         try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
 
         do {
-            currentConfig = try loadConfigFromDisk()
+            let config = try loadConfig(from: fileURL)
+            return .loaded(config)
+        } catch let error as NSError where error.domain == NSCocoaErrorDomain
+            && error.code == NSFileReadNoSuchFileError
+        {
+            let defaults = StatusBarConfig()
+            do {
+                try writeConfig(defaults, to: fileURL)
+                return .firstLaunch(defaults)
+            } catch {
+                return .parseFailed(error)
+            }
+        } catch {
+            return .parseFailed(error)
+        }
+    }
+
+    /// Call once from `AppDelegate`, before `Theme.configure`.
+    func bootstrap() {
+        let fm = FileManager.default
+        let outcome = Self.performBootstrapLoad(fileURL: fileURL)
+
+        switch outcome {
+        case let .loaded(config):
+            currentConfig = config
             // Record initial modification date so the FS watcher can skip
             // events where config.yml hasn't actually changed.
             // swiftformat:disable:next redundantSelf
@@ -72,18 +107,24 @@ final class ConfigLoader {
             }
             // swiftformat:disable:next redundantSelf
             logger.info("Loaded config from \(self.fileURL.path)")
-        } catch let error as NSError where error.domain == NSCocoaErrorDomain
-            && error.code == NSFileReadNoSuchFileError
-        {
+        case let .firstLaunch(config):
             isFirstLaunch = true
-            currentConfig = StatusBarConfig()
-            writeCurrentStateToDisk()
+            currentConfig = config
+            lastWriteTime = Date()
             // swiftformat:disable:next redundantSelf
             logger.info("Generated default config at \(self.fileURL.path)")
-        } catch {
-            logger.error("Failed to load config, using defaults: \(error.localizedDescription)")
+        case let .parseFailed(error):
+            logger.error("Failed to load config, keeping user file untouched: \(error.localizedDescription)")
             currentConfig = StatusBarConfig()
-            writeCurrentStateToDisk()
+            // Defer the notification so observers registered later in bootstrap still receive it.
+            let message = error.localizedDescription
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: .configParseError,
+                    object: nil,
+                    userInfo: ["message": message]
+                )
+            }
         }
 
         // Populate the widget config registry so Settings singletons can read initial values
@@ -101,11 +142,15 @@ final class ConfigLoader {
     // MARK: - YAML I/O
 
     /// Maximum config file size (1 MB) to prevent resource exhaustion (e.g. YAML billion laughs).
-    private static let maxConfigFileSize: UInt64 = 1_048_576
+    nonisolated static let maxConfigFileSize: UInt64 = 1_048_576
 
     /// Synchronous file I/O. Called during bootstrap (before run loop) and hot-reload
     /// (small YAML file, sub-millisecond). Kept synchronous intentionally.
     private func loadConfigFromDisk() throws -> StatusBarConfig {
+        try Self.loadConfig(from: fileURL)
+    }
+
+    nonisolated static func loadConfig(from fileURL: URL) throws -> StatusBarConfig {
         // Check file size before reading to prevent resource exhaustion
         let attrs = try FileManager.default.attributesOfItem(atPath: fileURL.path)
         let fileSize = attrs[.size] as? UInt64 ?? 0
@@ -120,6 +165,14 @@ final class ConfigLoader {
         let data = try Data(contentsOf: fileURL)
         let yaml = String(data: data, encoding: .utf8) ?? ""
         return try YAMLDecoder().decode(StatusBarConfig.self, from: yaml)
+    }
+
+    nonisolated static func writeConfig(_ config: StatusBarConfig, to fileURL: URL) throws {
+        let encoder = YAMLEncoder()
+        let rawYAML = try encoder.encode(config)
+        let yamlString = fixScientificNotation(rawYAML)
+        let data = Data(yamlString.utf8)
+        try data.write(to: fileURL, options: .atomic)
     }
 
     // MARK: - Apply config to live models
@@ -176,11 +229,7 @@ final class ConfigLoader {
         lastWriteTime = Date()
 
         do {
-            let encoder = YAMLEncoder()
-            let rawYAML = try encoder.encode(currentConfig)
-            let yamlString = Self.fixScientificNotation(rawYAML)
-            let data = Data(yamlString.utf8)
-            try data.write(to: fileURL, options: .atomic)
+            try Self.writeConfig(currentConfig, to: fileURL)
         } catch {
             logger.error("Failed to write config: \(error.localizedDescription)")
         }
@@ -303,8 +352,18 @@ final class ConfigLoader {
             }
             applyNewConfig(newConfig)
             logger.info("Config reloaded via IPC")
+        } catch let error as NSError where error.domain == NSCocoaErrorDomain
+            && error.code == NSFileReadNoSuchFileError
+        {
+            // Missing file — nothing to reload.
+            logger.error("Config reload via IPC: file not found")
         } catch {
             logger.error("Config reload via IPC failed: \(error.localizedDescription)")
+            NotificationCenter.default.post(
+                name: .configParseError,
+                object: nil,
+                userInfo: ["message": error.localizedDescription]
+            )
         }
     }
 

--- a/Sources/StatusBar/Config/StatusBarConfig.swift
+++ b/Sources/StatusBar/Config/StatusBarConfig.swift
@@ -108,6 +108,17 @@ struct BarConfig: Codable {
         p.widgetSpacing = CGFloat(widgetSpacing)
         p.widgetPaddingH = CGFloat(widgetPaddingH)
     }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let d = PreferencesModel.Defaults.self
+        height = try c.decodeIfPresent(Double.self, forKey: .height) ?? Double(d.barHeight)
+        cornerRadius = try c.decodeIfPresent(Double.self, forKey: .cornerRadius) ?? Double(d.barCornerRadius)
+        margin = try c.decodeIfPresent(Double.self, forKey: .margin) ?? Double(d.barMargin)
+        yOffset = try c.decodeIfPresent(Double.self, forKey: .yOffset) ?? Double(d.barYOffset)
+        widgetSpacing = try c.decodeIfPresent(Double.self, forKey: .widgetSpacing) ?? Double(d.widgetSpacing)
+        widgetPaddingH = try c.decodeIfPresent(Double.self, forKey: .widgetPaddingH) ?? Double(d.widgetPaddingH)
+    }
 }
 
 // MARK: - AppearanceConfig
@@ -181,6 +192,33 @@ struct AppearanceConfig: Codable {
         p.popupCornerRadius = CGFloat(popupCornerRadius)
         p.popupPadding = CGFloat(popupPadding)
     }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let d = PreferencesModel.Defaults.self
+        accent = try c.decodeIfPresent(HexColor.self, forKey: .accent) ?? HexColor(d.accentHex)
+        textPrimaryOpacity = try c.decodeIfPresent(
+            Double.self, forKey: .textPrimaryOpacity
+        ) ?? d.textPrimaryOpacity
+        textSecondaryOpacity = try c.decodeIfPresent(
+            Double.self, forKey: .textSecondaryOpacity
+        ) ?? d.textSecondaryOpacity
+        textTertiaryOpacity = try c.decodeIfPresent(
+            Double.self, forKey: .textTertiaryOpacity
+        ) ?? d.textTertiaryOpacity
+        green = try c.decodeIfPresent(HexColor.self, forKey: .green) ?? HexColor(d.greenHex)
+        yellow = try c.decodeIfPresent(HexColor.self, forKey: .yellow) ?? HexColor(d.yellowHex)
+        red = try c.decodeIfPresent(HexColor.self, forKey: .red) ?? HexColor(d.redHex)
+        cyan = try c.decodeIfPresent(HexColor.self, forKey: .cyan) ?? HexColor(d.cyanHex)
+        purple = try c.decodeIfPresent(HexColor.self, forKey: .purple) ?? HexColor(d.purpleHex)
+        barTint = try c.decodeIfPresent(HexColor.self, forKey: .barTint) ?? HexColor(d.barTintHex)
+        barTintOpacity = try c.decodeIfPresent(Double.self, forKey: .barTintOpacity) ?? d.barTintOpacity
+        shadowEnabled = try c.decodeIfPresent(Bool.self, forKey: .shadowEnabled) ?? d.shadowEnabled
+        popupCornerRadius = try c.decodeIfPresent(
+            Double.self, forKey: .popupCornerRadius
+        ) ?? Double(d.popupCornerRadius)
+        popupPadding = try c.decodeIfPresent(Double.self, forKey: .popupPadding) ?? Double(d.popupPadding)
+    }
 }
 
 // MARK: - TypographyConfig
@@ -213,6 +251,15 @@ struct TypographyConfig: Codable {
         p.labelFontSize = CGFloat(labelFontSize)
         p.smallFontSize = CGFloat(smallFontSize)
         p.monoFontSize = CGFloat(monoFontSize)
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let d = PreferencesModel.Defaults.self
+        iconFontSize = try c.decodeIfPresent(Double.self, forKey: .iconFontSize) ?? Double(d.iconFontSize)
+        labelFontSize = try c.decodeIfPresent(Double.self, forKey: .labelFontSize) ?? Double(d.labelFontSize)
+        smallFontSize = try c.decodeIfPresent(Double.self, forKey: .smallFontSize) ?? Double(d.smallFontSize)
+        monoFontSize = try c.decodeIfPresent(Double.self, forKey: .monoFontSize) ?? Double(d.monoFontSize)
     }
 }
 
@@ -251,6 +298,16 @@ struct GraphsConfig: Codable {
         p.cpuGraphHex = cpuColor.rawValue
         p.memoryGraphHex = memoryColor.rawValue
     }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let d = PreferencesModel.Defaults.self
+        width = try c.decodeIfPresent(Double.self, forKey: .width) ?? Double(d.graphWidth)
+        height = try c.decodeIfPresent(Double.self, forKey: .height) ?? Double(d.graphHeight)
+        dataPoints = try c.decodeIfPresent(Int.self, forKey: .dataPoints) ?? d.graphDataPoints
+        cpuColor = try c.decodeIfPresent(HexColor.self, forKey: .cpuColor) ?? HexColor(d.cpuGraphHex)
+        memoryColor = try c.decodeIfPresent(HexColor.self, forKey: .memoryColor) ?? HexColor(d.memoryGraphHex)
+    }
 }
 
 // MARK: - BehaviorConfig
@@ -287,6 +344,18 @@ struct BehaviorConfig: Codable {
         p.autoHideFadeDuration = autoHideFadeDuration
         p.launchAtLogin = launchAtLogin
         p.hideInFullscreen = hideInFullscreen
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let d = PreferencesModel.Defaults.self
+        autoHide = try c.decodeIfPresent(Bool.self, forKey: .autoHide) ?? d.autoHideEnabled
+        autoHideDwellTime = try c.decodeIfPresent(Double.self, forKey: .autoHideDwellTime) ?? d.autoHideDwellTime
+        autoHideFadeDuration = try c.decodeIfPresent(
+            Double.self, forKey: .autoHideFadeDuration
+        ) ?? d.autoHideFadeDuration
+        launchAtLogin = try c.decodeIfPresent(Bool.self, forKey: .launchAtLogin) ?? d.launchAtLogin
+        hideInFullscreen = try c.decodeIfPresent(Bool.self, forKey: .hideInFullscreen) ?? d.hideInFullscreen
     }
 }
 

--- a/Tests/StatusBarTests/ConfigLoaderTests.swift
+++ b/Tests/StatusBarTests/ConfigLoaderTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 @testable import StatusBar
 import Testing
+import Yams
+
+// MARK: - FixScientificNotationTests
 
 struct FixScientificNotationTests {
     @Test("Converts positive exponent to integer")
@@ -66,5 +69,75 @@ struct FixScientificNotationTests {
         let input = "value: 1e+3"
         let result = ConfigLoader.fixScientificNotation(input)
         #expect(result == "value: 1000")
+    }
+}
+
+// MARK: - ConfigLoaderBootstrapTests
+
+struct ConfigLoaderBootstrapTests {
+    /// Make a unique temp file path under the system temp dir.
+    private func tempFileURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("statusbar-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("config.yml")
+    }
+
+    @Test("Parse failure does not overwrite user's config on disk")
+    func parseFailurePreservesUserFile() throws {
+        let url = tempFileURL()
+        let corrupted = "this: is:\n  not: [valid yaml because:\n"
+        try Data(corrupted.utf8).write(to: url, options: .atomic)
+
+        let outcome = ConfigLoader.performBootstrapLoad(fileURL: url)
+
+        // Must report parse failure
+        guard case let .parseFailed(error) = outcome else {
+            Issue.record("Expected .parseFailed outcome, got \(outcome)")
+            return
+        }
+        // The error must not be "file not found" (that would collapse into firstLaunch)
+        let nsError = error as NSError
+        #expect(!(nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileReadNoSuchFileError))
+
+        // File contents must be byte-for-byte identical to what we wrote
+        let after = try String(contentsOf: url, encoding: .utf8)
+        #expect(after == corrupted)
+    }
+
+    @Test("First-launch (file absent) writes a default config to disk")
+    func firstLaunchWritesDefault() throws {
+        let url = tempFileURL()
+        // Ensure file does not exist
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+
+        let outcome = ConfigLoader.performBootstrapLoad(fileURL: url)
+
+        guard case .firstLaunch = outcome else {
+            Issue.record("Expected .firstLaunch outcome, got \(outcome)")
+            return
+        }
+        #expect(FileManager.default.fileExists(atPath: url.path))
+
+        // And the written file must be decodable
+        let reloaded = try ConfigLoader.loadConfig(from: url)
+        #expect(reloaded.global.bar.height == Double(PreferencesModel.Defaults.barHeight))
+    }
+
+    @Test("Existing valid YAML loads without rewriting disk")
+    func validFileLoadsCleanly() throws {
+        let url = tempFileURL()
+        let config = StatusBarConfig()
+        try ConfigLoader.writeConfig(config, to: url)
+        let before = try Data(contentsOf: url)
+
+        let outcome = ConfigLoader.performBootstrapLoad(fileURL: url)
+
+        guard case .loaded = outcome else {
+            Issue.record("Expected .loaded outcome, got \(outcome)")
+            return
+        }
+        let after = try Data(contentsOf: url)
+        #expect(before == after)
     }
 }

--- a/Tests/StatusBarTests/ConfigRoundTripTests.swift
+++ b/Tests/StatusBarTests/ConfigRoundTripTests.swift
@@ -114,4 +114,101 @@ struct ConfigRoundTripTests {
         #expect(decoded.widgets.isEmpty)
         #expect(decoded.widgetSettings.isEmpty)
     }
+
+    // MARK: - Partial-YAML migration safety
+
+    @Test("BarConfig fills missing fields with defaults")
+    func barConfigPartialDecode() throws {
+        let yaml = "height: 50\n"
+        let decoded = try YAMLDecoder().decode(BarConfig.self, from: yaml)
+        let d = PreferencesModel.Defaults.self
+
+        #expect(decoded.height == 50)
+        // Missing fields fall back to defaults.
+        #expect(decoded.cornerRadius == Double(d.barCornerRadius))
+        #expect(decoded.margin == Double(d.barMargin))
+        #expect(decoded.yOffset == Double(d.barYOffset))
+        #expect(decoded.widgetSpacing == Double(d.widgetSpacing))
+        #expect(decoded.widgetPaddingH == Double(d.widgetPaddingH))
+    }
+
+    @Test("AppearanceConfig fills missing fields with defaults")
+    func appearanceConfigPartialDecode() throws {
+        let yaml = "accent: \"#FF00AA\"\nshadowEnabled: false\n"
+        let decoded = try YAMLDecoder().decode(AppearanceConfig.self, from: yaml)
+        let d = PreferencesModel.Defaults.self
+
+        #expect(decoded.accent == HexColor(0xFF00AA))
+        #expect(decoded.shadowEnabled == false)
+        // Defaults for omitted fields.
+        #expect(decoded.green == HexColor(d.greenHex))
+        #expect(decoded.yellow == HexColor(d.yellowHex))
+        #expect(decoded.red == HexColor(d.redHex))
+        #expect(decoded.barTintOpacity == d.barTintOpacity)
+        #expect(decoded.popupCornerRadius == Double(d.popupCornerRadius))
+        #expect(decoded.popupPadding == Double(d.popupPadding))
+    }
+
+    @Test("BehaviorConfig fills missing fields with defaults")
+    func behaviorConfigPartialDecode() throws {
+        let yaml = "autoHide: false\n"
+        let decoded = try YAMLDecoder().decode(BehaviorConfig.self, from: yaml)
+        let d = PreferencesModel.Defaults.self
+
+        #expect(decoded.autoHide == false)
+        #expect(decoded.autoHideDwellTime == d.autoHideDwellTime)
+        #expect(decoded.autoHideFadeDuration == d.autoHideFadeDuration)
+        #expect(decoded.launchAtLogin == d.launchAtLogin)
+        #expect(decoded.hideInFullscreen == d.hideInFullscreen)
+    }
+
+    @Test("TypographyConfig fills missing fields with defaults")
+    func typographyConfigPartialDecode() throws {
+        let yaml = "labelFontSize: 16\n"
+        let decoded = try YAMLDecoder().decode(TypographyConfig.self, from: yaml)
+        let d = PreferencesModel.Defaults.self
+
+        #expect(decoded.labelFontSize == 16)
+        #expect(decoded.iconFontSize == Double(d.iconFontSize))
+        #expect(decoded.smallFontSize == Double(d.smallFontSize))
+        #expect(decoded.monoFontSize == Double(d.monoFontSize))
+    }
+
+    @Test("GraphsConfig fills missing fields with defaults")
+    func graphsConfigPartialDecode() throws {
+        let yaml = "dataPoints: 120\n"
+        let decoded = try YAMLDecoder().decode(GraphsConfig.self, from: yaml)
+        let d = PreferencesModel.Defaults.self
+
+        #expect(decoded.dataPoints == 120)
+        #expect(decoded.width == Double(d.graphWidth))
+        #expect(decoded.height == Double(d.graphHeight))
+        #expect(decoded.cpuColor == HexColor(d.cpuGraphHex))
+        #expect(decoded.memoryColor == HexColor(d.memoryGraphHex))
+    }
+
+    @Test("Empty YAML dict decodes each sub-config to full defaults")
+    func emptyDictDecodesToDefaults() throws {
+        let empty = "{}\n"
+        let bar = try YAMLDecoder().decode(BarConfig.self, from: empty)
+        let appearance = try YAMLDecoder().decode(AppearanceConfig.self, from: empty)
+        let typography = try YAMLDecoder().decode(TypographyConfig.self, from: empty)
+        let graphs = try YAMLDecoder().decode(GraphsConfig.self, from: empty)
+        let behavior = try YAMLDecoder().decode(BehaviorConfig.self, from: empty)
+        let notifications = try YAMLDecoder().decode(NotificationsConfig.self, from: empty)
+
+        let defBar = BarConfig()
+        let defAppearance = AppearanceConfig()
+        let defTypography = TypographyConfig()
+        let defGraphs = GraphsConfig()
+        let defBehavior = BehaviorConfig()
+        let defNotifications = NotificationsConfig()
+
+        #expect(bar.height == defBar.height)
+        #expect(appearance.accent == defAppearance.accent)
+        #expect(typography.iconFontSize == defTypography.iconFontSize)
+        #expect(graphs.dataPoints == defGraphs.dataPoints)
+        #expect(behavior.autoHide == defBehavior.autoHide)
+        #expect(notifications.batteryLow == defNotifications.batteryLow)
+    }
 }


### PR DESCRIPTION
## Summary
Prevents user settings from being destroyed when `config.yml` fails to parse, and makes every `GlobalConfig` sub-struct tolerant of fields that were added in newer app versions.

## Changes
- `ConfigLoader.bootstrap()` now distinguishes three outcomes (`.loaded` / `.firstLaunch` / `.parseFailed`) and **never writes defaults to disk on parse failure** — only truly missing files trigger a default write.
- Parse failures from bootstrap now also post `.configParseError` so the AppDelegate alert fires, keeping behavior consistent with the FS-watch and IPC reload paths. IPC `reloadFromDisk()` now posts the same notification on parse failure (previously logged silently).
- `BarConfig`, `AppearanceConfig`, `TypographyConfig`, `GraphsConfig`, `BehaviorConfig` all got custom `init(from:)` implementations that use `decodeIfPresent` + `PreferencesModel.Defaults` fallbacks. Previously only `NotificationsConfig` had this. Without it, any newly-added field in a future release would fail to decode on an existing user's `config.yml` and — via the first bug above — wipe their entire configuration.
- Extracted `performBootstrapLoad`, `loadConfig`, `writeConfig` as `nonisolated static` helpers so the bootstrap logic is directly testable.

## Notes
- `encode(to:)` remains synthesized — only the decode side is customized.
- New tests:
  - `ConfigLoaderBootstrapTests` — verifies a corrupted file is **not** overwritten, and that missing files still get defaults written (regression guard).
  - `ConfigRoundTripTests` partial-YAML cases for all 6 sub-configs — verifies field omission falls back to defaults.
- All 210 tests pass.