### PR TITLE
fix: keep widget lifecycle consistent across layout changes and stops

### DIFF
--- a/Sources/StatusBar/Core/WidgetRegistry.swift
+++ b/Sources/StatusBar/Core/WidgetRegistry.swift
@@ -238,6 +238,11 @@ final class WidgetRegistry: WidgetRegistryProtocol {
 
     func applyLayout(_ entries: [WidgetLayoutEntry]) {
         let knownIDs = Set(allWidgets.keys)
+        // Capture prior visibility (treat widgets missing from the old layout as hidden,
+        // matching setVisible's invariant that start() is only called on becoming visible).
+        let oldVisibility: [String: Bool] = Dictionary(
+            uniqueKeysWithValues: layout.map { ($0.id, $0.isVisible) }
+        )
         // Keep only entries for widgets that actually exist
         var newLayout = entries.filter { knownIDs.contains($0.id) }
         // Append any registered widgets not in the preset (preserving defaultLayout order)
@@ -250,6 +255,20 @@ final class WidgetRegistry: WidgetRegistryProtocol {
             newLayout.append(entry)
         }
         layout = newLayout
+
+        // Propagate visibility changes so timers / observers track the new layout.
+        for entry in newLayout {
+            let wasVisible = oldVisibility[entry.id] ?? false
+            guard wasVisible != entry.isVisible else {
+                continue
+            }
+            if entry.isVisible {
+                allWidgets[entry.id]?.start()
+            } else {
+                allWidgets[entry.id]?.stop()
+            }
+        }
+
         persist()
     }
 

--- a/Sources/StatusBar/Services/NextEventTracker.swift
+++ b/Sources/StatusBar/Services/NextEventTracker.swift
@@ -105,6 +105,10 @@ final class NextEventTracker {
     }
 
     private func observeStoreChanges() {
+        if let existing = storeObserver {
+            NotificationCenter.default.removeObserver(existing)
+            storeObserver = nil
+        }
         storeObserver = NotificationCenter.default.addObserver(
             forName: .EKEventStoreChanged,
             object: nil,

--- a/Sources/StatusBar/Widgets/CPUGraphWidget.swift
+++ b/Sources/StatusBar/Widgets/CPUGraphWidget.swift
@@ -113,14 +113,17 @@ final class CPUGraphWidget: StatusBarWidget, EventEmitting {
     private let buffer = GraphDataBuffer(capacity: 50)
     private let service = SystemMonitorService.shared
     private var graphValues: [Double] = []
+    private var isRunning = false
 
     func start() {
+        isRunning = true
         restartTimer()
         observeTimerSettings()
         observeRenderSettings()
     }
 
     func stop() {
+        isRunning = false
         timer?.cancel()
     }
 
@@ -149,8 +152,11 @@ final class CPUGraphWidget: StatusBarWidget, EventEmitting {
             _ = CPUGraphSettings.shared.updateInterval
         } onChange: { [weak self] in
             Task { @MainActor in
-                self?.restartTimer()
-                self?.observeTimerSettings()
+                guard let self, self.isRunning else {
+                    return
+                }
+                self.restartTimer()
+                self.observeTimerSettings()
             }
         }
     }
@@ -161,7 +167,10 @@ final class CPUGraphWidget: StatusBarWidget, EventEmitting {
             _ = CPUGraphSettings.shared.thresholds
         } onChange: { [weak self] in
             Task { @MainActor in
-                self?.observeRenderSettings()
+                guard let self, self.isRunning else {
+                    return
+                }
+                self.observeRenderSettings()
             }
         }
     }

--- a/Sources/StatusBar/Widgets/DateWidget.swift
+++ b/Sources/StatusBar/Widgets/DateWidget.swift
@@ -143,8 +143,13 @@ final class DateWidget: StatusBarWidget, EventEmitting {
     private var timeUntilStart: TimeInterval?
     private var isLoadingEvents = true
     private var notifiedThresholds: [String: Set<Int>] = [:]
+    private var isRunning = false
 
     func start() {
+        guard !isRunning else {
+            return
+        }
+        isRunning = true
         applyFormat()
         updateDate()
         timer = Timer.publish(every: 60, tolerance: 6, on: .main, in: .common)
@@ -155,8 +160,11 @@ final class DateWidget: StatusBarWidget, EventEmitting {
     }
 
     func stop() {
+        isRunning = false
         timer?.cancel()
+        timer = nil
         tracker?.stop()
+        tracker = nil
         popupPanel?.hidePopup()
     }
 
@@ -281,10 +289,13 @@ final class DateWidget: StatusBarWidget, EventEmitting {
             _ = DateSettings.shared.notifyMinutesBefore
         } onChange: { [weak self] in
             Task { @MainActor in
-                self?.applyFormat()
-                self?.updateDate()
-                self?.startTrackerIfNeeded()
-                self?.observeSettings()
+                guard let self, self.isRunning else {
+                    return
+                }
+                self.applyFormat()
+                self.updateDate()
+                self.startTrackerIfNeeded()
+                self.observeSettings()
             }
         }
     }

--- a/Sources/StatusBar/Widgets/FrontAppWidget.swift
+++ b/Sources/StatusBar/Widgets/FrontAppWidget.swift
@@ -36,6 +36,9 @@ final class FrontAppWidget: StatusBarWidget, EventEmitting {
     private var observer: NSObjectProtocol?
 
     func start() {
+        guard observer == nil else {
+            return
+        }
         appName = NSWorkspace.shared.frontmostApplication?.localizedName ?? ""
         observer = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,

--- a/Sources/StatusBar/Widgets/InputSourceWidget.swift
+++ b/Sources/StatusBar/Widgets/InputSourceWidget.swift
@@ -33,6 +33,9 @@ final class InputSourceWidget: StatusBarWidget, EventEmitting {
     private var service: InputSourceService?
 
     func start() {
+        guard service == nil else {
+            return
+        }
         service = InputSourceService { [weak self] in
             self?.refresh()
         }

--- a/Sources/StatusBar/Widgets/MemoryGraphWidget.swift
+++ b/Sources/StatusBar/Widgets/MemoryGraphWidget.swift
@@ -113,14 +113,17 @@ final class MemoryGraphWidget: StatusBarWidget, EventEmitting {
     private let buffer = GraphDataBuffer(capacity: 50)
     private let service = SystemMonitorService.shared
     private var graphValues: [Double] = []
+    private var isRunning = false
 
     func start() {
+        isRunning = true
         restartTimer()
         observeTimerSettings()
         observeRenderSettings()
     }
 
     func stop() {
+        isRunning = false
         timer?.cancel()
     }
 
@@ -149,8 +152,11 @@ final class MemoryGraphWidget: StatusBarWidget, EventEmitting {
             _ = MemoryGraphSettings.shared.updateInterval
         } onChange: { [weak self] in
             Task { @MainActor in
-                self?.restartTimer()
-                self?.observeTimerSettings()
+                guard let self, self.isRunning else {
+                    return
+                }
+                self.restartTimer()
+                self.observeTimerSettings()
             }
         }
     }
@@ -161,7 +167,10 @@ final class MemoryGraphWidget: StatusBarWidget, EventEmitting {
             _ = MemoryGraphSettings.shared.thresholds
         } onChange: { [weak self] in
             Task { @MainActor in
-                self?.observeRenderSettings()
+                guard let self, self.isRunning else {
+                    return
+                }
+                self.observeRenderSettings()
             }
         }
     }

--- a/Sources/StatusBar/Widgets/MicCameraWidget.swift
+++ b/Sources/StatusBar/Widgets/MicCameraWidget.swift
@@ -56,6 +56,9 @@ final class MicCameraWidget: StatusBarWidget, EventEmitting {
     private var service: MicCameraService?
 
     func start() {
+        guard service == nil else {
+            return
+        }
         service = MicCameraService { [weak self] state in
             Task { @MainActor in
                 guard let self else {

--- a/Sources/StatusBar/Widgets/NetworkWidget.swift
+++ b/Sources/StatusBar/Widgets/NetworkWidget.swift
@@ -71,13 +71,16 @@ final class NetworkWidget: StatusBarWidget, EventEmitting {
     private let service = NetworkService()
     private var uploadSpeed = "0 kB/s"
     private var downloadSpeed = "0 kB/s"
+    private var isRunning = false
 
     func start() {
+        isRunning = true
         restartTimer()
         observeSettings()
     }
 
     func stop() {
+        isRunning = false
         timer?.cancel()
     }
 
@@ -102,8 +105,11 @@ final class NetworkWidget: StatusBarWidget, EventEmitting {
             _ = NetworkSettings.shared.updateInterval
         } onChange: { [weak self] in
             Task { @MainActor in
-                self?.restartTimer()
-                self?.observeSettings()
+                guard let self, self.isRunning else {
+                    return
+                }
+                self.restartTimer()
+                self.observeSettings()
             }
         }
     }

--- a/Sources/StatusBar/Widgets/VolumeWidget.swift
+++ b/Sources/StatusBar/Widgets/VolumeWidget.swift
@@ -49,6 +49,9 @@ final class VolumeWidget: StatusBarWidget, EventEmitting {
     private var popupPanel: PopupPanel?
 
     func start() {
+        guard service == nil else {
+            return
+        }
         service = AudioService { [weak self] vol in
             Task { @MainActor in
                 guard let self else {
@@ -77,6 +80,7 @@ final class VolumeWidget: StatusBarWidget, EventEmitting {
 
     func stop() {
         service?.stop()
+        service = nil
         popupPanel?.hidePopup()
     }
 

--- a/Tests/StatusBarTests/WidgetRegistryTests.swift
+++ b/Tests/StatusBarTests/WidgetRegistryTests.swift
@@ -1,6 +1,42 @@
 import Foundation
 @testable import StatusBar
+import StatusBarKit
+import SwiftUI
 import Testing
+
+// MARK: - FakeLifecycleWidget
+
+/// Minimal StatusBarWidget used to observe start()/stop() calls in lifecycle tests.
+/// IDs use the `"test-fake-"` prefix so they don't collide with real widgets in the
+/// shared WidgetRegistry singleton.
+@MainActor
+final class FakeLifecycleWidget: StatusBarWidget {
+    let id: String
+    let position: WidgetPosition
+    let updateInterval: TimeInterval? = nil
+
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    init(id: String, position: WidgetPosition = .left) {
+        self.id = id
+        self.position = position
+    }
+
+    func start() {
+        startCount += 1
+    }
+
+    func stop() {
+        stopCount += 1
+    }
+
+    func body() -> some View {
+        EmptyView()
+    }
+}
+
+// MARK: - WidgetRegistryTests
 
 @MainActor
 struct WidgetRegistryTests {
@@ -31,5 +67,81 @@ struct WidgetRegistryTests {
     @Test("Empty string returns empty")
     func emptyDisplayName() {
         #expect(WidgetRegistry.displayName(for: "") == "")
+    }
+
+    // MARK: - applyLayout lifecycle
+
+    /// applyLayout should start widgets whose isVisible flipped false -> true so that
+    /// hot-reload / preset switches correctly activate newly-visible widgets.
+    @Test("applyLayout starts widgets that become visible")
+    func applyLayoutStartsNewlyVisibleWidget() {
+        let registry = WidgetRegistry.shared
+        let widget = FakeLifecycleWidget(id: "test-fake-becomes-visible-\(UUID().uuidString)")
+        registry.register(widget)
+        defer { registry.unregisterWidgets(ids: [widget.id]) }
+
+        // Baseline: widget hidden.
+        registry.applyLayout([
+            WidgetLayoutEntry(id: widget.id, section: .left, sortIndex: 0, isVisible: false),
+        ])
+        let startsBefore = widget.startCount
+        let stopsBefore = widget.stopCount
+
+        // Flip to visible.
+        registry.applyLayout([
+            WidgetLayoutEntry(id: widget.id, section: .left, sortIndex: 0, isVisible: true),
+        ])
+
+        #expect(widget.startCount == startsBefore + 1)
+        #expect(widget.stopCount == stopsBefore)
+    }
+
+    /// applyLayout should stop widgets whose isVisible flipped true -> false so that
+    /// timers / observers held by the widget are released on hot-reload.
+    @Test("applyLayout stops widgets that become hidden")
+    func applyLayoutStopsNewlyHiddenWidget() {
+        let registry = WidgetRegistry.shared
+        let widget = FakeLifecycleWidget(id: "test-fake-becomes-hidden-\(UUID().uuidString)")
+        registry.register(widget)
+        defer { registry.unregisterWidgets(ids: [widget.id]) }
+
+        // Baseline: widget visible.
+        registry.applyLayout([
+            WidgetLayoutEntry(id: widget.id, section: .left, sortIndex: 0, isVisible: true),
+        ])
+        let startsBefore = widget.startCount
+        let stopsBefore = widget.stopCount
+
+        // Flip to hidden.
+        registry.applyLayout([
+            WidgetLayoutEntry(id: widget.id, section: .left, sortIndex: 0, isVisible: false),
+        ])
+
+        #expect(widget.stopCount == stopsBefore + 1)
+        #expect(widget.startCount == startsBefore)
+    }
+
+    /// Re-applying an identical layout must be a no-op for lifecycle; otherwise the
+    /// Mach / IOKit / NotificationCenter observers held by widgets double-register.
+    @Test("applyLayout with no visibility change does not call start or stop")
+    func applyLayoutNoChangeDoesNotToggle() {
+        let registry = WidgetRegistry.shared
+        let widget = FakeLifecycleWidget(id: "test-fake-stable-\(UUID().uuidString)")
+        registry.register(widget)
+        defer { registry.unregisterWidgets(ids: [widget.id]) }
+
+        registry.applyLayout([
+            WidgetLayoutEntry(id: widget.id, section: .left, sortIndex: 0, isVisible: true),
+        ])
+        let startsBefore = widget.startCount
+        let stopsBefore = widget.stopCount
+
+        // Apply the same visibility; section/sortIndex changes still count as "no visibility diff".
+        registry.applyLayout([
+            WidgetLayoutEntry(id: widget.id, section: .right, sortIndex: 5, isVisible: true),
+        ])
+
+        #expect(widget.startCount == startsBefore)
+        #expect(widget.stopCount == stopsBefore)
     }
 }


### PR DESCRIPTION
## Summary
Fixes several widget-lifecycle bugs that left timers, observers, and observation tasks running after a widget was supposed to be stopped, or silently skipped starting a widget that should have become visible.

## Changes
Split into three commits:

**`fix: make widget start idempotent and clear calendar store observer`**
- `FrontAppWidget`, `VolumeWidget`, `MicCameraWidget`, `InputSourceWidget` now guard their `start()` against re-entry, matching the existing `BatteryWidget` pattern. Previously a second `start()` without an intervening `stop()` would double-register observers or leak the previous service instance (e.g., a CoreAudio listener for `VolumeWidget`).
- `VolumeWidget.stop()` now nils out `service` so the guard stays honest across restarts.
- `NextEventTracker.observeStoreChanges()` now removes the previous `storeObserver` before registering a new one. Previously a second call silently leaked the old observer.

**`fix: propagate visibility changes through applyLayout`**
- `WidgetRegistry.applyLayout()` now diffs old vs. new visibility and calls `start()` / `stop()` accordingly. Previously YAML hot-reload (`ConfigLoader.applyNewConfig()` → `applyLayout()`) would leave hidden widgets' timers running and never start freshly-visible widgets.

**`fix: gate widget observation tasks after stop`**
- `CPUGraphWidget`, `MemoryGraphWidget`, `NetworkWidget`, `DateWidget` now track an `isRunning` flag, and the `withObservationTracking` onChange chains bail out when the widget is stopped. Previously, because the `WidgetRegistry` holds widgets strongly, `[weak self]` was not enough to break the recursion — settings changes after `stop()` would silently restart the timer.
- `DateWidget.stop()` additionally nils `timer` and `tracker` so its new idempotent `start()` guard is honest.

## Notes
- New tests in `WidgetRegistryTests`: `applyLayout` fires `start` on false→true, fires `stop` on true→false, and fires neither on unchanged visibility. Uses a `FakeLifecycleWidget` + UUID-suffixed IDs to avoid leaking into the shared registry.
- All 204 tests pass.