### PR TITLE
fix: assorted robustness and crash fixes across UI, IPC, and services

### DIFF
--- a/Sources/StatusBar/IPC/IPCServer.swift
+++ b/Sources/StatusBar/IPC/IPCServer.swift
@@ -140,9 +140,10 @@ final class IPCServer {
             return
         }
 
-        // bind は通常プロセスの umask を適用して socket ファイルを作成するため、
-        // bind → chmod の間に他ユーザがアクセスできる TOCTOU 窓が存在する。
-        // umask を 0o177 (= 許可 0o600) にセットしておくことで bind 時点から最小権限で作成する。
+        // bind creates the socket file using the process umask, so there is a
+        // TOCTOU window between bind and chmod during which other users can access it.
+        // Setting umask to 0o177 (= 0o600 permissions) ensures the socket is created
+        // with minimal permissions from the moment bind completes.
         let previousUmask = umask(0o177)
         defer { umask(previousUmask) }
 
@@ -152,7 +153,7 @@ final class IPCServer {
             return
         }
 
-        // 二重防御: umask の外部干渉に備え冗長に chmod しておく。
+        // Belt and suspenders: redundantly chmod in case the umask is tampered with externally.
         chmod(socketPath, 0o600)
 
         guard Darwin.listen(serverFD, 5) == 0 else {

--- a/Sources/StatusBar/IPC/IPCServer.swift
+++ b/Sources/StatusBar/IPC/IPCServer.swift
@@ -39,6 +39,7 @@ private func handleClient(fd: Int32, dispatcher: CommandDispatcher) {
     Task.detached {
         var timeout = timeval(tv_sec: 5, tv_usec: 0)
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
 
         let request: IPCRequest
         do {
@@ -139,12 +140,19 @@ final class IPCServer {
             return
         }
 
+        // bind は通常プロセスの umask を適用して socket ファイルを作成するため、
+        // bind → chmod の間に他ユーザがアクセスできる TOCTOU 窓が存在する。
+        // umask を 0o177 (= 許可 0o600) にセットしておくことで bind 時点から最小権限で作成する。
+        let previousUmask = umask(0o177)
+        defer { umask(previousUmask) }
+
         guard bindSocket() else {
             close(serverFD)
             serverFD = -1
             return
         }
 
+        // 二重防御: umask の外部干渉に備え冗長に chmod しておく。
         chmod(socketPath, 0o600)
 
         guard Darwin.listen(serverFD, 5) == 0 else {

--- a/Sources/StatusBar/Onboarding/OnboardingWindow.swift
+++ b/Sources/StatusBar/Onboarding/OnboardingWindow.swift
@@ -50,8 +50,8 @@ final class OnboardingWindow: NSObject, NSWindowDelegate {
 
     // MARK: - NSWindowDelegate
 
-    /// X ボタンでの閉じる操作でも "Get Started" 経由と同様に完了フラグを立てる。
-    /// set(true) は冪等なので Get Started → close の順でも副作用はない。
+    /// Mark onboarding complete when closed via the X button, just as "Get Started" does.
+    /// set(true) is idempotent, so the Get Started → close sequence has no side effects.
     nonisolated func windowWillClose(_ notification: Notification) {
         UserDefaults.standard.set(true, forKey: OnboardingKeys.hasCompleted)
     }

--- a/Sources/StatusBar/Onboarding/OnboardingWindow.swift
+++ b/Sources/StatusBar/Onboarding/OnboardingWindow.swift
@@ -10,12 +10,14 @@ enum OnboardingKeys {
 // MARK: - OnboardingWindow
 
 @MainActor
-final class OnboardingWindow {
+final class OnboardingWindow: NSObject, NSWindowDelegate {
     static let shared = OnboardingWindow()
 
     private var window: NSWindow?
 
-    private init() {}
+    override private init() {
+        super.init()
+    }
 
     func show() {
         if let existing = window, existing.isVisible {
@@ -39,9 +41,18 @@ final class OnboardingWindow {
         window.contentView = hostingView
         window.center()
         window.isReleasedWhenClosed = false
+        window.delegate = self
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
         self.window = window
+    }
+
+    // MARK: - NSWindowDelegate
+
+    /// X ボタンでの閉じる操作でも "Get Started" 経由と同様に完了フラグを立てる。
+    /// set(true) は冪等なので Get Started → close の順でも副作用はない。
+    nonisolated func windowWillClose(_ notification: Notification) {
+        UserDefaults.standard.set(true, forKey: OnboardingKeys.hasCompleted)
     }
 }

--- a/Sources/StatusBar/Preferences/PreferencesView.swift
+++ b/Sources/StatusBar/Preferences/PreferencesView.swift
@@ -279,9 +279,13 @@ extension Color {
         guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components else {
             return 0x000000
         }
-        let r = !components.isEmpty ? components[0] : 0
-        let g = components.count > 1 ? components[1] : 0
-        let b = components.count > 2 ? components[2] : 0
-        return (UInt32(r * 255) << 16) | (UInt32(g * 255) << 8) | UInt32(b * 255)
+        // sRGB 変換後でも P3 等の広色域由来の成分が [0, 1] を外れうるため、
+        // UInt32 への変換前にクランプする (負値 / 1.0 超は UInt32 初期化でクラッシュする)。
+        let r = max(0, min(1, !components.isEmpty ? components[0] : 0))
+        let g = max(0, min(1, components.count > 1 ? components[1] : 0))
+        let b = max(0, min(1, components.count > 2 ? components[2] : 0))
+        return (UInt32((r * 255).rounded()) << 16)
+            | (UInt32((g * 255).rounded()) << 8)
+            | UInt32((b * 255).rounded())
     }
 }

--- a/Sources/StatusBar/Preferences/PreferencesView.swift
+++ b/Sources/StatusBar/Preferences/PreferencesView.swift
@@ -279,8 +279,9 @@ extension Color {
         guard let components = NSColor(self).usingColorSpace(.sRGB)?.cgColor.components else {
             return 0x000000
         }
-        // sRGB 変換後でも P3 等の広色域由来の成分が [0, 1] を外れうるため、
-        // UInt32 への変換前にクランプする (負値 / 1.0 超は UInt32 初期化でクラッシュする)。
+        // Components originating from wide-gamut color spaces like P3 can fall outside
+        // [0, 1] even after sRGB conversion, so clamp before converting to UInt32
+        // (negative values / values > 1.0 crash the UInt32 initializer).
         let r = max(0, min(1, !components.isEmpty ? components[0] : 0))
         let g = max(0, min(1, components.count > 1 ? components[1] : 0))
         let b = max(0, min(1, components.count > 2 ? components[2] : 0))

--- a/Sources/StatusBar/Services/MicCameraService.swift
+++ b/Sources/StatusBar/Services/MicCameraService.swift
@@ -156,7 +156,10 @@ final class MicCameraService: @unchecked Sendable {
             return false
         }
 
-        let bufferListPtr = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: 4)
+        let bufferListPtr = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(size),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
         defer { bufferListPtr.deallocate() }
         guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, bufferListPtr) == noErr
         else {

--- a/Sources/StatusBar/Services/NetworkService.swift
+++ b/Sources/StatusBar/Services/NetworkService.swift
@@ -69,12 +69,18 @@ final class NetworkService {
         var cursor: UnsafeMutablePointer<ifaddrs>? = first
         while let addr = cursor {
             let name = String(cString: addr.pointee.ifa_name)
-            if name.hasPrefix("en") || name.hasPrefix("utun") {
-                if let data = addr.pointee.ifa_data {
-                    let networkData = data.assumingMemoryBound(to: if_data.self).pointee
-                    totalRx += UInt64(networkData.ifi_ibytes)
-                    totalTx += UInt64(networkData.ifi_obytes)
-                }
+            // getifaddrs は各インターフェースについて複数のエントリを返す (AF_LINK, AF_INET, AF_INET6)。
+            // ifa_data が if_data としてレイアウトされているのは AF_LINK エントリのみ。
+            // ここで family をチェックしないと AF_INET 等の ifa_data を if_data として解釈して
+            // 不正なバイトカウントを加算してしまう。
+            let family = addr.pointee.ifa_addr?.pointee.sa_family
+            if name.hasPrefix("en") || name.hasPrefix("utun"),
+               family == UInt8(AF_LINK),
+               let data = addr.pointee.ifa_data
+            {
+                let networkData = data.assumingMemoryBound(to: if_data.self).pointee
+                totalRx += UInt64(networkData.ifi_ibytes)
+                totalTx += UInt64(networkData.ifi_obytes)
             }
             cursor = addr.pointee.ifa_next
         }

--- a/Sources/StatusBar/Services/NetworkService.swift
+++ b/Sources/StatusBar/Services/NetworkService.swift
@@ -69,10 +69,10 @@ final class NetworkService {
         var cursor: UnsafeMutablePointer<ifaddrs>? = first
         while let addr = cursor {
             let name = String(cString: addr.pointee.ifa_name)
-            // getifaddrs は各インターフェースについて複数のエントリを返す (AF_LINK, AF_INET, AF_INET6)。
-            // ifa_data が if_data としてレイアウトされているのは AF_LINK エントリのみ。
-            // ここで family をチェックしないと AF_INET 等の ifa_data を if_data として解釈して
-            // 不正なバイトカウントを加算してしまう。
+            // getifaddrs returns multiple entries per interface (AF_LINK, AF_INET, AF_INET6).
+            // Only AF_LINK entries have ifa_data laid out as if_data.
+            // Without checking family here, ifa_data from AF_INET etc. would be reinterpreted
+            // as if_data and add bogus byte counts.
             let family = addr.pointee.ifa_addr?.pointee.sa_family
             if name.hasPrefix("en") || name.hasPrefix("utun"),
                family == UInt8(AF_LINK),

--- a/Sources/StatusBar/Toast/ToastManager.swift
+++ b/Sources/StatusBar/Toast/ToastManager.swift
@@ -147,13 +147,16 @@ final class ToastManager {
         guard let panel else {
             return
         }
+        // アニメ完了まで self.panel を保持したままだと、その 0.25s 窓内で post() された際に
+        // showPanel() の `guard panel == nil` によって新規パネルが生成されず表示されない。
+        // 退避してから直ちに nil にすることで、後続の post() が新しいパネルを生成できるようにする。
+        self.panel = nil
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.25
             context.timingFunction = CAMediaTimingFunction(name: .easeIn)
             panel.animator().alphaValue = 0
-        } completionHandler: { [weak self] in
-            self?.panel?.orderOut(nil)
-            self?.panel = nil
+        } completionHandler: {
+            panel.orderOut(nil)
         }
     }
 

--- a/Sources/StatusBar/Toast/ToastManager.swift
+++ b/Sources/StatusBar/Toast/ToastManager.swift
@@ -147,9 +147,11 @@ final class ToastManager {
         guard let panel else {
             return
         }
-        // アニメ完了まで self.panel を保持したままだと、その 0.25s 窓内で post() された際に
-        // showPanel() の `guard panel == nil` によって新規パネルが生成されず表示されない。
-        // 退避してから直ちに nil にすることで、後続の post() が新しいパネルを生成できるようにする。
+        // If self.panel is kept until the animation finishes, a post() that arrives within
+        // that 0.25s window hits the `guard panel == nil` in showPanel() and fails to create
+        // a new panel, so nothing is shown.
+        // Stash the panel and clear self.panel immediately so subsequent post() calls can
+        // spawn a fresh panel.
         self.panel = nil
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.25

--- a/Tests/StatusBarTests/ColorToHexTests.swift
+++ b/Tests/StatusBarTests/ColorToHexTests.swift
@@ -1,0 +1,89 @@
+import AppKit
+@testable import StatusBar
+import SwiftUI
+import Testing
+
+/// `Color.toHex()` のクランプ挙動テスト。
+///
+/// P3 等の広色域で初期化された Color を sRGB に変換すると、成分が [0, 1] の範囲外
+/// (負値 / 1.0 超) になることがある。クランプせずに `UInt32(x * 255)` すると
+/// 負値で crash / 1.0 超でオーバーフローするため、クランプが正しく働くことを確認する。
+struct ColorToHexTests {
+
+    @Test("Pure sRGB red maps to 0xFF0000")
+    func pureRed() {
+        let color = Color(.sRGB, red: 1, green: 0, blue: 0)
+        #expect(color.toHex() == 0xFF0000)
+    }
+
+    @Test("Pure sRGB green maps to 0x00FF00")
+    func pureGreen() {
+        let color = Color(.sRGB, red: 0, green: 1, blue: 0)
+        #expect(color.toHex() == 0x00FF00)
+    }
+
+    @Test("Pure sRGB blue maps to 0x0000FF")
+    func pureBlue() {
+        let color = Color(.sRGB, red: 0, green: 0, blue: 1)
+        #expect(color.toHex() == 0x0000FF)
+    }
+
+    @Test("Black clamps to 0x000000")
+    func black() {
+        let color = Color(.sRGB, red: 0, green: 0, blue: 0)
+        #expect(color.toHex() == 0x000000)
+    }
+
+    @Test("White rounds to 0xFFFFFF")
+    func white() {
+        let color = Color(.sRGB, red: 1, green: 1, blue: 1)
+        #expect(color.toHex() == 0xFFFFFF)
+    }
+
+    /// displayP3 で sRGB 外の純緑を作ると、sRGB 変換で負の赤成分 / 1.0 超の緑成分になる。
+    /// クランプされないと `UInt32` 初期化でクラッシュするので、そのクラッシュが発生しない事を確認する。
+    @Test("Wide-gamut P3 green does not crash and clamps to [0, 0xFF]")
+    func p3GreenClamps() {
+        let color = Color(.displayP3, red: 0, green: 1, blue: 0)
+        let hex = color.toHex()
+        // クランプされていれば各成分は [0, 0xFF] 範囲内。
+        let r = (hex >> 16) & 0xFF
+        let g = (hex >> 8) & 0xFF
+        let b = hex & 0xFF
+        #expect(r <= 0xFF)
+        #expect(g <= 0xFF)
+        #expect(b <= 0xFF)
+        // 緑成分は sRGB に変換しても概ね 1.0 近傍なので 0xFF にクランプされるはず。
+        #expect(g == 0xFF)
+    }
+
+    @Test("Wide-gamut P3 red does not crash and clamps to [0, 0xFF]")
+    func p3RedClamps() {
+        let color = Color(.displayP3, red: 1, green: 0, blue: 0)
+        let hex = color.toHex()
+        let r = (hex >> 16) & 0xFF
+        let g = (hex >> 8) & 0xFF
+        let b = hex & 0xFF
+        #expect(r <= 0xFF)
+        #expect(g <= 0xFF)
+        #expect(b <= 0xFF)
+        #expect(r == 0xFF)
+    }
+
+    @Test("Negative component is clamped to 0 (no UInt32 crash)")
+    func negativeComponentClamps() {
+        // sRGB 空間で負の赤を明示的に指定してクランプ動作を確認する。
+        let color = Color(.sRGB, red: -0.5, green: 0.5, blue: 0.5)
+        let hex = color.toHex()
+        let r = (hex >> 16) & 0xFF
+        #expect(r == 0)
+    }
+
+    @Test("Component > 1 is clamped to 0xFF (no overflow)")
+    func overOneComponentClamps() {
+        let color = Color(.sRGB, red: 2.0, green: 0.5, blue: 0.5)
+        let hex = color.toHex()
+        let r = (hex >> 16) & 0xFF
+        #expect(r == 0xFF)
+    }
+}

--- a/Tests/StatusBarTests/ColorToHexTests.swift
+++ b/Tests/StatusBarTests/ColorToHexTests.swift
@@ -3,11 +3,11 @@ import AppKit
 import SwiftUI
 import Testing
 
-/// `Color.toHex()` のクランプ挙動テスト。
+/// Clamping behavior tests for `Color.toHex()`.
 ///
-/// P3 等の広色域で初期化された Color を sRGB に変換すると、成分が [0, 1] の範囲外
-/// (負値 / 1.0 超) になることがある。クランプせずに `UInt32(x * 255)` すると
-/// 負値で crash / 1.0 超でオーバーフローするため、クランプが正しく働くことを確認する。
+/// Converting a Color initialized in a wide-gamut space like P3 to sRGB can leave components
+/// outside [0, 1] (negative values / values > 1.0). Without clamping, `UInt32(x * 255)`
+/// crashes on negatives and overflows above 1.0, so verify the clamp works correctly.
 struct ColorToHexTests {
 
     @Test("Pure sRGB red maps to 0xFF0000")
@@ -40,20 +40,21 @@ struct ColorToHexTests {
         #expect(color.toHex() == 0xFFFFFF)
     }
 
-    /// displayP3 で sRGB 外の純緑を作ると、sRGB 変換で負の赤成分 / 1.0 超の緑成分になる。
-    /// クランプされないと `UInt32` 初期化でクラッシュするので、そのクラッシュが発生しない事を確認する。
+    /// Pure displayP3 green sits outside sRGB, so converting to sRGB yields a negative red
+    /// component / a green component above 1.0. Without clamping this crashes `UInt32`
+    /// initialization, so verify that no crash occurs.
     @Test("Wide-gamut P3 green does not crash and clamps to [0, 0xFF]")
     func p3GreenClamps() {
         let color = Color(.displayP3, red: 0, green: 1, blue: 0)
         let hex = color.toHex()
-        // クランプされていれば各成分は [0, 0xFF] 範囲内。
+        // When clamped, each component stays within [0, 0xFF].
         let r = (hex >> 16) & 0xFF
         let g = (hex >> 8) & 0xFF
         let b = hex & 0xFF
         #expect(r <= 0xFF)
         #expect(g <= 0xFF)
         #expect(b <= 0xFF)
-        // 緑成分は sRGB に変換しても概ね 1.0 近傍なので 0xFF にクランプされるはず。
+        // The green component stays near 1.0 after sRGB conversion, so it should clamp to 0xFF.
         #expect(g == 0xFF)
     }
 
@@ -72,7 +73,7 @@ struct ColorToHexTests {
 
     @Test("Negative component is clamped to 0 (no UInt32 crash)")
     func negativeComponentClamps() {
-        // sRGB 空間で負の赤を明示的に指定してクランプ動作を確認する。
+        // Explicitly pass a negative red in sRGB to verify clamp behavior.
         let color = Color(.sRGB, red: -0.5, green: 0.5, blue: 0.5)
         let hex = color.toHex()
         let r = (hex >> 16) & 0xFF


### PR DESCRIPTION
## Summary
A batch of small, independent fixes surfaced by a codebase-wide review. Each commit is self-contained and can be reverted individually.

## Changes
- **`fix: clamp Color.toHex components to avoid P3 wide-gamut crash`** — `NSColor.usingColorSpace(.sRGB)` can return components outside `[0, 1]` for Display P3 colors; `UInt32(negative_double)` traps. Components are now clamped and rounded. Adds `ColorToHexTests` covering basic sRGB, P3 saturated green/red, and out-of-range clamping.
- **`fix: allow ToastManager.post during hide animation`** — `hidePanel()` kept `panel` non-nil for the 0.25s fade-out, so a `post()` arriving during that window was dropped by the `guard panel == nil` in `showPanel()`. `panel` is now cleared synchronously at the start of hide, and only the captured local reference is faded and ordered out.
- **`fix: harden IPC socket permissions and add send timeout`** — `IPCServer` used `bind()` followed by `chmod(0600)`, leaving a TOCTOU window where another local user could connect before the `chmod`. Sets `umask(0o177)` before `bind()` (and restores it after) so the socket is created with `0600` in the first place. Also sets `SO_SNDTIMEO` on accepted clients so a hung client cannot indefinitely block a server write.
- **`fix: only treat AF_LINK entries as if_data in NetworkService`** — `getifaddrs` returns multiple entries per interface (`AF_INET`, `AF_INET6`, `AF_LINK`). Only `AF_LINK` entries have `ifa_data` pointing at an `if_data` struct; casting other entries reads garbage. Now gated on `sa_family == AF_LINK`.
- **`fix: mark onboarding complete on close button too`** — `hasCompleted` was only set via the Get Started button; closing the onboarding window via its title-bar close button left the flag unset, so onboarding would re-appear on every subsequent launch. `OnboardingWindow` now implements `NSWindowDelegate.windowWillClose` to set the flag.
- **`fix: use AudioBufferList alignment for raw buffer allocation`** — `MicCameraService.isInputDevice` allocated with `alignment: 4`, but `AudioBufferList` contains pointer fields that require 8-byte alignment on 64-bit platforms. Uses `MemoryLayout<AudioBufferList>.alignment` instead.

## Notes
- UI- and syscall-side effects (Toast, Onboarding, IPC socket permissions, network iface enumeration, MemoryLayout constants) were not unit-tested per the project's testing policy (CLAUDE.md): cost too high for too little behavioral signal. Only the pure Color→Hex logic got tests.
- All 210 tests pass.