### PR TITLE
feat: plugins.yml and plugins-lock.yml manifest workflow

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5ae0552fd8293c72e2848b8b747530368e91fdc31b0132d11c733d6c5c902781",
+  "originHash" : "6d04fc12440ea20e3f8122b1c43618d8858c918c6ccb0d608833a6526f010591",
   "pins" : [
     {
       "identity" : "statusbarkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hytfjwr/StatusBarKit",
       "state" : {
-        "revision" : "3f90df4958504fd920668740a3bc5230311b9b70",
-        "version" : "1.8.0"
+        "revision" : "5b5426f7b240975ec644d8c40be4f001d33fb277",
+        "version" : "1.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     name: "StatusBar",
     platforms: [.macOS(.v26)],
     dependencies: [
-        .package(url: "https://github.com/hytfjwr/StatusBarKit", from: "1.8.0"),
+        .package(url: "https://github.com/hytfjwr/StatusBarKit", from: "1.9.0"),
         .package(url: "https://github.com/jpsim/Yams", from: "6.2.1"),
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.58.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),

--- a/README.md
+++ b/README.md
@@ -60,9 +60,20 @@ make run-app   # Release build
 
 ## Plugins
 
-StatusBar supports third-party plugins distributed as `.statusplugin.zip` archives via GitHub Releases. Install and manage plugins entirely through the Preferences UI — no CLI required.
+StatusBar supports third-party plugins distributed as `.statusplugin.zip` archives via GitHub Releases. Install and manage plugins through the Preferences UI, the `sbar plugins` CLI, or by hand-editing `plugins.yml`.
 
 <img width="722" height="673" alt="Plugin Management UI" src="https://github.com/user-attachments/assets/9eed1e64-fda5-48d9-88a6-03f885442770" />
+
+### Manifest & lockfile
+
+Plugin state lives in two YAML files alongside `config.yml`:
+
+- **`~/.config/statusbar/plugins.yml`** — declarative manifest. Each entry is `source: github:owner/repo` plus `version: "1.2.0"` (exact) or `version: latest`. Safe to commit alongside your dotfiles.
+- **`~/.config/statusbar/plugins-lock.yml`** — resolved snapshot. Auto-generated and updated by sync; records the exact tag, asset URL, and zip SHA-256 needed to reinstall the same versions on another machine.
+
+GUI install/uninstall, manual edits, and `sbar plugins sync` all update the same files. A "Sync Plugins" button in Preferences (and `sbar plugins sync`) reconciles the manifest with what's installed: missing plugins are downloaded, declared updates applied, and plugins removed from `plugins.yml` are auto-uninstalled.
+
+Run `sbar plugins sync --frozen` to install strictly from the lockfile without contacting GitHub — useful for CI or restoring a known-good environment.
 
 ### Official Plugins
 
@@ -83,6 +94,8 @@ Use the [plugin template](https://github.com/hytfjwr/statusbar-plugin-template) 
 ## Configuration
 
 A default config is generated at `~/.config/statusbar/config.yml` on first launch. The file is hot-reloaded — edits are applied instantly without restarting. All settings are also available through the Preferences window (Apple Menu > Preferences).
+
+Plugin state is split across `plugins.yml` (declarative manifest) and `plugins-lock.yml` (resolved versions and checksums) in the same directory — see [Plugins](#plugins) for details.
 
 <details>
 <summary>Bar</summary>
@@ -279,6 +292,12 @@ sbar subscribe front_app_switched | jq '.payload'
 sbar toast --title "Deploy done" --message "v1.2.3 shipped" --level success
 sbar toast --title "CPU Warning" --level warning --duration 10
 sbar toast --title "Error" --level error --action-label "Open Logs" --action "open /var/log"
+
+# Plugin manifest sync (reads ~/.config/statusbar/plugins.yml)
+sbar plugins list
+sbar plugins list --json
+sbar plugins sync
+sbar plugins sync --frozen   # install strictly from plugins-lock.yml, no network resolution
 
 # Relaunch the app
 sbar reload

--- a/Sources/StatusBar/App/AppDelegate.swift
+++ b/Sources/StatusBar/App/AppDelegate.swift
@@ -20,24 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ConfigLoader.shared.scheduleWrite()
         }
 
-        // Built-in widgets
-        registry.register(AppleMenuWidget())
-        registry.register(ChevronWidget())
-        registry.register(FrontAppWidget())
-        registry.register(FocusTimerWidget())
-        registry.register(MicCameraWidget())
-        registry.register(NetworkWidget())
-        registry.register(MemoryGraphWidget())
-        registry.register(CPUGraphWidget())
-        registry.register(DiskUsageWidget())
-        registry.register(BatteryWidget())
-        registry.register(VolumeWidget())
-        registry.register(InputSourceWidget())
-        registry.register(DateWidget())
-        registry.register(TimeWidget())
-        let bluetoothWidget = BluetoothWidget()
-        registry.register(bluetoothWidget)
-        BluetoothWidgetLocator.register(bluetoothWidget)
+        registerBuiltInWidgets(into: registry)
 
         // Plugin manifest manager — must run before DylibPluginLoader so that
         // first-run migration sees the existing registry before any auto-registration.
@@ -92,6 +75,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 alert.runModal()
             }
         }
+    }
+
+    private func registerBuiltInWidgets(into registry: WidgetRegistry) {
+        registry.register(AppleMenuWidget())
+        registry.register(ChevronWidget())
+        registry.register(FrontAppWidget())
+        registry.register(FocusTimerWidget())
+        registry.register(MicCameraWidget())
+        registry.register(NetworkWidget())
+        registry.register(MemoryGraphWidget())
+        registry.register(CPUGraphWidget())
+        registry.register(DiskUsageWidget())
+        registry.register(BatteryWidget())
+        registry.register(VolumeWidget())
+        registry.register(InputSourceWidget())
+        registry.register(DateWidget())
+        registry.register(TimeWidget())
+        let bluetoothWidget = BluetoothWidget()
+        registry.register(bluetoothWidget)
+        BluetoothWidgetLocator.register(bluetoothWidget)
     }
 
     /// Set up a minimal main menu so standard text editing shortcuts (Cmd+C/V/X/A) work.

--- a/Sources/StatusBar/App/AppDelegate.swift
+++ b/Sources/StatusBar/App/AppDelegate.swift
@@ -39,6 +39,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         registry.register(bluetoothWidget)
         BluetoothWidgetLocator.register(bluetoothWidget)
 
+        // Plugin manifest manager — must run before DylibPluginLoader so that
+        // first-run migration sees the existing registry before any auto-registration.
+        PluginsManager.shared.bootstrap()
+
         // Dylib plugins (user-installed from ~/.config/statusbar/plugins/)
         DylibPluginLoader.shared.loadAll(into: registry)
 
@@ -117,6 +121,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         IPCServer.shared.stop()
         NotificationService.shared.stop()
         controller?.teardown()
+        PluginsManager.shared.teardown()
         ConfigLoader.shared.teardown()
     }
 }

--- a/Sources/StatusBar/IPC/CommandDispatcher.swift
+++ b/Sources/StatusBar/IPC/CommandDispatcher.swift
@@ -20,6 +20,8 @@ final class CommandDispatcher {
             ReloadCommandHandler(),
             TriggerCommandHandler(),
             ToastCommandHandler(),
+            PluginsSyncCommandHandler(),
+            PluginsListCommandHandler(),
         ]
         handlers = Dictionary(uniqueKeysWithValues: all.map { ($0.commandKey, $0) })
     }
@@ -70,6 +72,8 @@ extension IPCCommand {
         case .subscribe: "subscribe"
         case .trigger: "trigger"
         case .showToast: "showToast"
+        case .pluginsSync: "pluginsSync"
+        case .pluginsList: "pluginsList"
         @unknown default: "unknown"
         }
     }

--- a/Sources/StatusBar/IPC/Handlers/PluginsListCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/PluginsListCommandHandler.swift
@@ -1,0 +1,13 @@
+import StatusBarKit
+
+@MainActor
+struct PluginsListCommandHandler: CommandHandling {
+    let commandKey = "pluginsList"
+
+    func handle(_ command: IPCCommand) throws -> IPCPayload {
+        guard case .pluginsList = command else {
+            throw IPCError.unknownCommand
+        }
+        return .pluginList(PluginsManager.shared.manifestEntryDTOs())
+    }
+}

--- a/Sources/StatusBar/IPC/Handlers/PluginsSyncCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/PluginsSyncCommandHandler.swift
@@ -1,0 +1,41 @@
+import StatusBarKit
+
+@MainActor
+struct PluginsSyncCommandHandler: CommandHandling {
+    let commandKey = "pluginsSync"
+
+    func handle(_ command: IPCCommand) throws -> IPCPayload {
+        guard case let .pluginsSync(frozen) = command else {
+            throw IPCError.unknownCommand
+        }
+        // Sync is long-running (network + downloads). Run it in a detached task and
+        // acknowledge immediately; surface the outcome through toast notifications.
+        Task { @MainActor in
+            do {
+                let result = try await PluginsManager.shared.sync(frozen: frozen)
+                postResultToast(result, frozen: frozen)
+            } catch {
+                ToastManager.shared.post(ToastRequest(
+                    title: "Plugin sync failed",
+                    message: error.localizedDescription,
+                    icon: "xmark.circle",
+                    level: .error,
+                    duration: 6
+                ))
+            }
+        }
+        return .ok
+    }
+
+    @MainActor
+    private func postResultToast(_ result: PluginsSyncResult, frozen: Bool) {
+        let title = frozen ? "Plugin sync (frozen)" : "Plugin sync"
+        ToastManager.shared.post(ToastRequest(
+            title: title,
+            message: result.summary,
+            icon: result.hasErrors ? "exclamationmark.triangle" : "checkmark.circle",
+            level: result.hasErrors ? .warning : .success,
+            duration: result.hasErrors ? 8 : 4
+        ))
+    }
+}

--- a/Sources/StatusBar/Plugins/GitHubPluginInstaller.swift
+++ b/Sources/StatusBar/Plugins/GitHubPluginInstaller.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import OSLog
 import StatusBarKit
@@ -17,6 +18,7 @@ enum GitHubPluginError: Error, LocalizedError {
     case incompatibleVersion(required: String, current: String)
     case untrustedDownloadURL(String)
     case rateLimited
+    case zipSHA256Mismatch(expected: String, actual: String)
 
     var errorDescription: String? {
         switch self {
@@ -40,8 +42,22 @@ enum GitHubPluginError: Error, LocalizedError {
             "Download URL is not from a trusted GitHub domain: \(url)"
         case .rateLimited:
             "GitHub API rate limit exceeded. Try again later or configure a personal access token."
+        case let .zipSHA256Mismatch(expected, actual):
+            "Lockfile SHA-256 mismatch — expected \(expected), got \(actual)"
         }
     }
+}
+
+// MARK: - InstallResult
+
+/// Detailed outcome of an install. Carries the resolved zip hash and download URL so the
+/// caller (`PluginsManager`) can update plugins-lock.yml.
+struct InstallResult {
+    let record: InstalledPluginRecord
+    /// SHA-256 of the downloaded .statusplugin.zip (hex, lowercase).
+    let zipSHA256: String
+    /// URL the zip was downloaded from (typically objects.githubusercontent.com).
+    let assetURL: String
 }
 
 // MARK: - GitHubPluginInstaller
@@ -67,42 +83,94 @@ final class GitHubPluginInstaller {
     // MARK: - Install
 
     /// Install a plugin from a GitHub repository URL.
-    /// The URL should be like: https://github.com/owner/repo
-    func install(from urlString: String) async throws -> InstalledPluginRecord {
-        // Parse owner/repo from URL
+    /// - Parameters:
+    ///   - urlString: A repository URL like `https://github.com/owner/repo`.
+    ///   - version: A specific release tag (e.g. `"1.2.0"`) or `nil` / `"latest"` for the latest release.
+    func install(from urlString: String, version: String? = nil) async throws -> InstallResult {
         let (owner, repo) = try parseGitHubURL(urlString)
-        logger.info("Installing plugin from \(owner)/\(repo)")
+        logger.info("Installing plugin from \(owner)/\(repo) (version: \(version ?? "latest"))")
 
-        // Fetch latest release
-        let release = try await fetchLatestRelease(owner: owner, repo: repo)
+        let release: GitHubRelease = if let version, version != "latest" {
+            try await fetchRelease(owner: owner, repo: repo, tag: version)
+        } else {
+            try await fetchLatestRelease(owner: owner, repo: repo)
+        }
         logger.info("Found release \(release.tagName) for \(owner)/\(repo)")
 
-        // Find .statusplugin.zip asset
         guard let asset = release.assets.first(where: { $0.name.hasSuffix(".statusplugin.zip") }) else {
             logger.error("No .statusplugin.zip asset in release \(release.tagName) for \(owner)/\(repo)")
             throw GitHubPluginError.noPluginAsset
         }
 
-        // Download and extract
         let zipData = try await downloadAsset(url: asset.browserDownloadURL)
         logger.info("Downloaded \(asset.name) (\(zipData.count) bytes)")
-        let (pluginBundle, tempDir) = try await extractAndValidate(zipData: zipData, assetName: asset.name)
+        let zipSHA256 = Self.hexHash(of: zipData)
+
+        let releaseVersion = Self.normalizeVersion(release.tagName)
+        let record = try await installFromZipData(
+            zipData: zipData,
+            assetName: asset.name,
+            owner: owner,
+            repo: repo,
+            resolvedVersion: releaseVersion
+        )
+
+        return InstallResult(record: record, zipSHA256: zipSHA256, assetURL: asset.browserDownloadURL)
+    }
+
+    /// Install (or re-install) a plugin using a lockfile entry. Downloads from the recorded
+    /// asset URL and verifies the SHA-256 before placing the bundle on disk.
+    func installFromLock(
+        sourceURL: String,
+        assetURL: String,
+        expectedSHA256: String,
+        resolvedVersion: String
+    ) async throws -> InstalledPluginRecord {
+        let (owner, repo) = try parseGitHubURL(sourceURL)
+        logger.info("Restoring \(owner)/\(repo) @ \(resolvedVersion) from lockfile")
+
+        let zipData = try await downloadAsset(url: assetURL)
+        let actualSHA = Self.hexHash(of: zipData)
+        guard actualSHA == expectedSHA256.lowercased() else {
+            logger.error("SHA-256 mismatch for \(owner)/\(repo) — expected \(expectedSHA256), got \(actualSHA)")
+            throw GitHubPluginError.zipSHA256Mismatch(expected: expectedSHA256, actual: actualSHA)
+        }
+
+        // Asset name is unused beyond logging; derive a reasonable label from the URL.
+        let assetName = URL(string: assetURL)?.lastPathComponent ?? "plugin.statusplugin.zip"
+        return try await installFromZipData(
+            zipData: zipData,
+            assetName: assetName,
+            owner: owner,
+            repo: repo,
+            resolvedVersion: resolvedVersion
+        )
+    }
+
+    /// Shared install pipeline: extract, validate, place on disk, register in the store.
+    private func installFromZipData(
+        zipData: Data,
+        assetName: String,
+        owner: String,
+        repo: String,
+        resolvedVersion: String
+    ) async throws -> InstalledPluginRecord {
+        let (pluginBundle, tempDir) = try await extractAndValidate(zipData: zipData, assetName: assetName)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        // Read and validate manifest
         let manifest = try readAndValidateManifest(in: pluginBundle)
-
-        // Place bundle on disk
         let destURL = try placeBundle(pluginBundle, in: pluginsDirectory)
-
-        // Register in plugin store
-        let releaseVersion = Self.normalizeVersion(release.tagName)
         let record = try registerRecord(
             manifest: manifest, destURL: destURL,
-            owner: owner, repo: repo, releaseVersion: releaseVersion
+            owner: owner, repo: repo, releaseVersion: resolvedVersion
         )
-        logger.info("Installed plugin \(manifest.name) v\(releaseVersion)")
+        logger.info("Installed plugin \(manifest.name) v\(resolvedVersion)")
         return record
+    }
+
+    /// SHA-256 of a blob as a lowercase hex string.
+    static func hexHash(of data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
     /// Extract zip data to a temp directory and validate the extracted contents.
@@ -179,10 +247,7 @@ final class GitHubPluginInstaller {
     /// Move the plugin bundle to the plugins directory, replacing any existing version.
     private func placeBundle(_ pluginBundle: URL, in pluginsDirectory: URL) throws -> URL {
         let fm = FileManager.default
-        if !fm.fileExists(atPath: pluginsDirectory.path) {
-            try fm.createDirectory(at: pluginsDirectory, withIntermediateDirectories: true)
-        }
-
+        try fm.createDirectory(at: pluginsDirectory, withIntermediateDirectories: true)
         let destURL = pluginsDirectory.appendingPathComponent(pluginBundle.lastPathComponent)
         do { try fm.removeItem(at: destURL) } catch CocoaError.fileNoSuchFile { /* first install */ }
         try fm.moveItem(at: pluginBundle, to: destURL)
@@ -353,6 +418,67 @@ final class GitHubPluginInstaller {
         }
 
         return (owner: owner, repo: repo)
+    }
+
+    /// Resolve the latest release tag (normalized — no `v` prefix) without downloading the asset.
+    /// Used by `PluginsManager` to short-circuit sync when `plugins.yml` declares `version: latest`
+    /// but the lockfile already references the same tag.
+    func latestTagName(owner: String, repo: String) async throws -> String {
+        let release = try await fetchLatestRelease(owner: owner, repo: repo)
+        return Self.normalizeVersion(release.tagName)
+    }
+
+    /// Fetch a specific release by its tag name. Tries the tag verbatim and, if not found,
+    /// falls back to the `v`-prefixed form (handles `1.2.0` vs `v1.2.0` interchangeably).
+    private func fetchRelease(owner: String, repo: String, tag: String) async throws -> GitHubRelease {
+        let candidates: [String] = if tag.hasPrefix("v") || tag.hasPrefix("V") {
+            [tag, String(tag.dropFirst())]
+        } else {
+            [tag, "v\(tag)"]
+        }
+        var lastError: (any Error)?
+        for candidate in candidates {
+            do {
+                return try await fetchReleaseExact(owner: owner, repo: repo, tag: candidate)
+            } catch GitHubPluginError.noReleaseFound {
+                lastError = GitHubPluginError.noReleaseFound
+                continue
+            } catch {
+                throw error
+            }
+        }
+        throw lastError ?? GitHubPluginError.noReleaseFound
+    }
+
+    private func fetchReleaseExact(owner: String, repo: String, tag: String) async throws -> GitHubRelease {
+        let encoded = tag.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? tag
+        let urlString = "https://api.github.com/repos/\(owner)/\(repo)/releases/tags/\(encoded)"
+        guard let url = URL(string: urlString) else {
+            throw GitHubPluginError.invalidURL(urlString)
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            logger.error("Network request failed for \(owner)/\(repo)@\(tag): \(error.localizedDescription)")
+            throw GitHubPluginError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GitHubPluginError.noReleaseFound
+        }
+        if httpResponse.statusCode == 403 || httpResponse.statusCode == 429 {
+            throw GitHubPluginError.rateLimited
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw GitHubPluginError.noReleaseFound
+        }
+        return try JSONDecoder().decode(GitHubRelease.self, from: data)
     }
 
     private func fetchLatestRelease(owner: String, repo: String) async throws -> GitHubRelease {

--- a/Sources/StatusBar/Plugins/PluginsManager.swift
+++ b/Sources/StatusBar/Plugins/PluginsManager.swift
@@ -1,0 +1,449 @@
+import Foundation
+import OSLog
+import StatusBarKit
+
+private let logger = Logger(subsystem: "com.statusbar", category: "PluginsManager")
+
+// MARK: - PluginsSyncResult
+
+struct PluginsSyncResult {
+    var installed: [String] = []
+    var updated: [String] = []
+    var uninstalled: [String] = []
+    var skipped: [String] = []
+    var errors: [(source: String, message: String)] = []
+
+    var hasErrors: Bool {
+        !errors.isEmpty
+    }
+
+    var changedSomething: Bool {
+        !installed.isEmpty || !updated.isEmpty || !uninstalled.isEmpty
+    }
+
+    /// Short human-readable summary for toasts and UI labels.
+    var summary: String {
+        let parts: [String] = [
+            installed.isEmpty ? nil : "\(installed.count) installed",
+            updated.isEmpty ? nil : "\(updated.count) updated",
+            uninstalled.isEmpty ? nil : "\(uninstalled.count) removed",
+        ].compactMap(\.self)
+        return parts.isEmpty ? "Already up to date" : parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - PluginsManager
+
+/// Orchestrates plugins.yml + plugins-lock.yml + registry.json. Mirrors npm/pnpm semantics:
+/// plugins.yml is the user intent, plugins-lock.yml is the resolved snapshot, registry.json
+/// is the runtime state (enabled / installedAt / isLocal).
+@MainActor
+@Observable
+final class PluginsManager {
+    static let shared = PluginsManager()
+
+    let manifestStore: PluginsManifestStore
+    let pluginStore: PluginStore
+    let installer: GitHubPluginInstaller
+
+    /// True when plugins.yml has been edited externally since the last successful sync.
+    private(set) var isDirty: Bool = false
+
+    /// In-flight sync task — used to coalesce concurrent sync() callers.
+    private var inFlightSync: Task<PluginsSyncResult, any Error>?
+
+    private init() {
+        manifestStore = .shared
+        pluginStore = .shared
+        installer = .shared
+    }
+
+    /// Testable initializer accepting DI for manifest store, plugin store, and installer.
+    init(manifestStore: PluginsManifestStore, pluginStore: PluginStore, installer: GitHubPluginInstaller) {
+        self.manifestStore = manifestStore
+        self.pluginStore = pluginStore
+        self.installer = installer
+    }
+
+    // MARK: - Bootstrap
+
+    /// Called once from `AppDelegate` after `ConfigLoader.bootstrap()` and before
+    /// `DylibPluginLoader.loadAll(into:)`. Loads files, performs first-run migration,
+    /// and starts FS watching.
+    func bootstrap() {
+        manifestStore.load()
+        do {
+            if try migrateIfNeeded() {
+                ToastManager.shared.post(ToastRequest(
+                    title: "plugins.yml created",
+                    message: "Generated from existing plugin registry. Run sync to record checksums.",
+                    icon: "doc.text",
+                    level: .info,
+                    duration: 5
+                ))
+            }
+        } catch {
+            logger.error("Plugin manifest migration failed: \(error.localizedDescription)")
+        }
+        manifestStore.onExternalEdit = { [weak self] in
+            self?.handleExternalEdit()
+        }
+        manifestStore.startWatching()
+    }
+
+    func teardown() {
+        manifestStore.stopWatching()
+    }
+
+    // MARK: - Migration
+
+    /// On first run with an existing `registry.json` and no `plugins.yml`, generate
+    /// `plugins.yml` and `plugins-lock.yml` from the GitHub-installed plugins in the registry.
+    /// Local (`isLocal == true`) plugins are intentionally excluded.
+    /// - Returns: True when a new manifest+lock pair was written.
+    @discardableResult
+    func migrateIfNeeded() throws -> Bool {
+        if manifestStore.manifestExists {
+            return false
+        }
+        // PluginStore is loaded lazily by DylibPluginLoader; load it now so migration sees current state.
+        do {
+            try pluginStore.load()
+        } catch {
+            logger.warning("Could not load plugin registry for migration: \(error.localizedDescription)")
+        }
+        let githubPlugins = pluginStore.plugins.filter { !$0.isLocal && $0.githubURL != nil }
+        guard !githubPlugins.isEmpty else {
+            return false
+        }
+
+        var manifestEntries: [PluginsManifestEntry] = []
+        var lockEntries: [PluginsLockEntry] = []
+        for record in githubPlugins {
+            guard let source = PluginsManifestEntry.source(fromGitHubURL: record.githubURL) else {
+                continue
+            }
+            let normalizedVersion = GitHubPluginInstaller.normalizeVersion(record.version)
+            manifestEntries.append(PluginsManifestEntry(source: source, version: normalizedVersion))
+            // assetURL/zipSHA256 are unknown at migration time — the next non-frozen sync fills them in.
+            lockEntries.append(PluginsLockEntry(
+                source: source,
+                resolvedVersion: normalizedVersion,
+                pluginID: record.id,
+                bundleName: record.bundleName,
+                assetURL: nil,
+                zipSHA256: nil,
+                resolvedAt: record.installedAt
+            ))
+        }
+
+        try manifestStore.saveManifest(PluginsManifest(plugins: manifestEntries))
+        try manifestStore.saveLock(PluginsLock(plugins: lockEntries))
+        logger.info("Migrated \(githubPlugins.count) plugin(s) to plugins.yml + plugins-lock.yml")
+        return true
+    }
+
+    // MARK: - Sync
+
+    /// Reconcile installed plugins with `plugins.yml`. Installs missing plugins, updates
+    /// outdated ones, removes plugins that are no longer declared, and refreshes the lockfile.
+    /// Concurrent callers share a single in-flight sync to avoid duplicate downloads.
+    /// - Parameter frozen: When true, resolves only from `plugins-lock.yml` and never contacts GitHub.
+    func sync(frozen: Bool = false) async throws -> PluginsSyncResult {
+        if let existing = inFlightSync {
+            return try await existing.value
+        }
+        let task = Task { @MainActor [weak self] () throws -> PluginsSyncResult in
+            guard let self else {
+                return PluginsSyncResult()
+            }
+            defer { self.inFlightSync = nil }
+            return try await self.runSync(frozen: frozen)
+        }
+        inFlightSync = task
+        return try await task.value
+    }
+
+    private func runSync(frozen: Bool) async throws -> PluginsSyncResult {
+        let manifest = manifestStore.currentManifest
+        let lock = manifestStore.currentLock
+
+        var result = PluginsSyncResult()
+        var newLockEntries: [PluginsLockEntry] = []
+
+        for entry in manifest.plugins {
+            do {
+                let outcome = try await applyEntry(entry, lock: lock, frozen: frozen)
+                newLockEntries.append(outcome.lockEntry)
+                switch outcome.action {
+                case .skipped:
+                    result.skipped.append(outcome.lockEntry.pluginID)
+                case .installed:
+                    result.installed.append(outcome.lockEntry.pluginID)
+                case .updated:
+                    result.updated.append(outcome.lockEntry.pluginID)
+                }
+            } catch {
+                logger.error("Sync failed for \(entry.source): \(error.localizedDescription)")
+                result.errors.append((source: entry.source, message: error.localizedDescription))
+                // Preserve the previous lock entry if any, so partial failures don't lose state.
+                if let existing = lock.plugins.first(where: { $0.source == entry.source }) {
+                    newLockEntries.append(existing)
+                }
+            }
+        }
+
+        // Drift: registry has non-local plugins that are not declared in plugins.yml → uninstall.
+        // GitHub repository names are case-insensitive, so normalize for comparison.
+        let declaredSources = Set(manifest.plugins.map { $0.source.lowercased() })
+        for record in pluginStore.plugins where !record.isLocal {
+            guard let source = PluginsManifestEntry.source(fromGitHubURL: record.githubURL),
+                  !declaredSources.contains(source.lowercased())
+            else {
+                continue
+            }
+            do {
+                try installer.uninstall(pluginID: record.id)
+                DylibPluginLoader.shared.markForRemoval(pluginID: record.id, from: WidgetRegistry.shared)
+                result.uninstalled.append(record.id)
+            } catch {
+                logger.error("Failed to uninstall drift plugin \(record.id): \(error.localizedDescription)")
+                result.errors.append((source: source, message: error.localizedDescription))
+            }
+        }
+
+        try manifestStore.saveLock(PluginsLock(plugins: newLockEntries))
+        isDirty = false
+        return result
+    }
+
+    // MARK: - GUI helpers
+
+    /// Append (or update) an entry in plugins.yml and immediately install the plugin.
+    /// Installs first and only persists the manifest if the install succeeds, so a failed
+    /// network request never leaves a poisoned entry in plugins.yml.
+    @discardableResult
+    func add(source: String, version: String) async throws -> InstalledPluginRecord {
+        let entry = PluginsManifestEntry(source: source, version: version)
+        guard entry.parseGitHubSource() != nil else {
+            throw PluginsManifestError.invalidSource(source)
+        }
+
+        // Install first so a failure does not pollute plugins.yml.
+        let outcome = try await applyEntry(entry, lock: manifestStore.currentLock, frozen: false)
+
+        // Persist manifest (update existing entry if present, otherwise append).
+        var manifest = manifestStore.currentManifest
+        if let index = manifest.plugins.firstIndex(where: { $0.source == source }) {
+            manifest.plugins[index] = entry
+        } else {
+            manifest.plugins.append(entry)
+        }
+        try manifestStore.saveManifest(manifest)
+
+        // Persist lock.
+        var updatedLock = manifestStore.currentLock
+        if let index = updatedLock.plugins.firstIndex(where: { $0.source == source }) {
+            updatedLock.plugins[index] = outcome.lockEntry
+        } else {
+            updatedLock.plugins.append(outcome.lockEntry)
+        }
+        try manifestStore.saveLock(updatedLock)
+        return outcome.record
+    }
+
+    /// Remove a plugin: delete the bundle from disk, then drop the entry from manifest + lock + registry.
+    /// Bundle removal runs first so a permission error leaves the runtime state recoverable.
+    /// Local plugins (`isLocal == true`) cannot be removed via this path — they are not managed by plugins.yml.
+    func remove(pluginID: String) throws {
+        guard let record = pluginStore.record(forID: pluginID) else {
+            throw PluginsManagerError.unknownPlugin(pluginID)
+        }
+        if record.isLocal {
+            throw PluginsManagerError.localPluginNotManaged(pluginID)
+        }
+        guard let source = PluginsManifestEntry.source(fromGitHubURL: record.githubURL) else {
+            throw PluginsManagerError.unknownPlugin(pluginID)
+        }
+
+        // Delete bundle + registry record first (this can throw).
+        try installer.uninstall(pluginID: pluginID)
+        // Only then tear down the live widgets and update the manifest/lock files.
+        DylibPluginLoader.shared.markForRemoval(pluginID: pluginID, from: WidgetRegistry.shared)
+
+        var manifest = manifestStore.currentManifest
+        manifest.plugins.removeAll { $0.source == source }
+        try manifestStore.saveManifest(manifest)
+
+        var lock = manifestStore.currentLock
+        lock.plugins.removeAll { $0.source == source }
+        try manifestStore.saveLock(lock)
+    }
+
+    // MARK: - Manifest DTOs (for IPC)
+
+    /// Snapshot suitable for the `pluginsList` IPC response.
+    func manifestEntryDTOs() -> [PluginManifestEntryDTO] {
+        let manifest = manifestStore.currentManifest
+        let lock = manifestStore.currentLock
+        return manifest.plugins.map { entry in
+            let lockEntry = lock.plugins.first { $0.source == entry.source }
+            return PluginManifestEntryDTO(
+                source: entry.source,
+                declaredVersion: entry.version,
+                resolvedVersion: lockEntry?.resolvedVersion,
+                zipSHA256: lockEntry?.zipSHA256,
+                pluginID: lockEntry?.pluginID
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    /// Outcome of applying a single manifest entry during sync.
+    private struct EntryOutcome {
+        enum Action { case skipped, installed, updated }
+        let lockEntry: PluginsLockEntry
+        let record: InstalledPluginRecord
+        let action: Action
+    }
+
+    /// Resolve a single manifest entry, installing or skipping as needed.
+    private func applyEntry(
+        _ entry: PluginsManifestEntry,
+        lock: PluginsLock,
+        frozen: Bool
+    ) async throws -> EntryOutcome {
+        guard let (owner, repo) = entry.parseGitHubSource() else {
+            throw PluginsManifestError.invalidSource(entry.source)
+        }
+        let sourceURL = "https://github.com/\(owner)/\(repo)"
+        let existingLock = lock.plugins.first { $0.source == entry.source }
+
+        if frozen {
+            return try await applyFromLock(entry: entry, existingLock: existingLock, sourceURL: sourceURL)
+        }
+
+        // Decide the target version.
+        let targetVersion: String = if entry.isLatest {
+            try await installer.latestTagName(owner: owner, repo: repo)
+        } else {
+            GitHubPluginInstaller.normalizeVersion(entry.version)
+        }
+
+        // Skip when registry + lock already match the resolved version.
+        if let existingLock,
+           let record = upToDateRecord(for: existingLock, targetVersion: targetVersion)
+        {
+            return EntryOutcome(lockEntry: existingLock, record: record, action: .skipped)
+        }
+
+        let installVersion: String? = entry.isLatest ? nil : entry.version
+        let install = try await installer.install(from: sourceURL, version: installVersion)
+
+        let lockEntry = PluginsLockEntry(
+            source: entry.source,
+            resolvedVersion: install.record.version,
+            pluginID: install.record.id,
+            bundleName: install.record.bundleName,
+            assetURL: install.assetURL,
+            zipSHA256: install.zipSHA256,
+            resolvedAt: Date()
+        )
+        let action: EntryOutcome.Action = existingLock == nil ? .installed : .updated
+        return EntryOutcome(lockEntry: lockEntry, record: install.record, action: action)
+    }
+
+    /// Return the registry record matching a lock entry when the installed copy is already at the
+    /// target version and the lock has the asset/SHA needed for future frozen-mode restores.
+    private func upToDateRecord(
+        for lockEntry: PluginsLockEntry,
+        targetVersion: String
+    ) -> InstalledPluginRecord? {
+        guard lockEntry.resolvedVersion == targetVersion,
+              lockEntry.assetURL != nil,
+              lockEntry.zipSHA256 != nil,
+              let record = pluginStore.record(forID: lockEntry.pluginID),
+              GitHubPluginInstaller.normalizeVersion(record.version) == targetVersion
+        else {
+            return nil
+        }
+        return record
+    }
+
+    /// Frozen-mode application: resolve strictly from the lockfile and verify the SHA-256.
+    private func applyFromLock(
+        entry: PluginsManifestEntry,
+        existingLock: PluginsLockEntry?,
+        sourceURL: String
+    ) async throws -> EntryOutcome {
+        guard let lockEntry = existingLock else {
+            throw PluginsManagerError.frozenMissingLockEntry(entry.source)
+        }
+        guard let assetURL = lockEntry.assetURL, let expectedSHA = lockEntry.zipSHA256 else {
+            throw PluginsManagerError.frozenIncompleteLockEntry(entry.source)
+        }
+
+        if let record = pluginStore.record(forID: lockEntry.pluginID),
+           GitHubPluginInstaller.normalizeVersion(record.version) == lockEntry.resolvedVersion
+        {
+            return EntryOutcome(lockEntry: lockEntry, record: record, action: .skipped)
+        }
+
+        let record = try await installer.installFromLock(
+            sourceURL: sourceURL,
+            assetURL: assetURL,
+            expectedSHA256: expectedSHA,
+            resolvedVersion: lockEntry.resolvedVersion
+        )
+        return EntryOutcome(lockEntry: lockEntry, record: record, action: .installed)
+    }
+
+    // MARK: - External edit handling
+
+    private func handleExternalEdit() {
+        do {
+            try manifestStore.reload()
+            isDirty = true
+            ToastManager.shared.post(ToastRequest(
+                title: "plugins.yml changed",
+                message: "Run 'Sync Plugins' to apply",
+                icon: "doc.badge.gearshape",
+                level: .info,
+                duration: 6
+            ))
+        } catch {
+            // Don't update isDirty — the old in-memory manifest is still valid; surface the parse error.
+            logger.error("Failed to reload plugins.yml: \(error.localizedDescription)")
+            ToastManager.shared.post(ToastRequest(
+                title: "plugins.yml has a parse error",
+                message: error.localizedDescription,
+                icon: "exclamationmark.triangle",
+                level: .warning,
+                duration: 8
+            ))
+        }
+    }
+}
+
+// MARK: - PluginsManagerError
+
+enum PluginsManagerError: Error, LocalizedError {
+    case unknownPlugin(String)
+    case localPluginNotManaged(String)
+    case frozenMissingLockEntry(String)
+    case frozenIncompleteLockEntry(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unknownPlugin(id):
+            "Unknown plugin: \(id)"
+        case let .localPluginNotManaged(id):
+            "Local plugin \(id) is not managed by plugins.yml"
+        case let .frozenMissingLockEntry(source):
+            "frozen sync: no lockfile entry for \(source) — run a regular sync first"
+        case let .frozenIncompleteLockEntry(source):
+            "frozen sync: lockfile entry for \(source) is missing asset URL or checksum — run a regular sync first"
+        }
+    }
+}

--- a/Sources/StatusBar/Plugins/PluginsManifestStore.swift
+++ b/Sources/StatusBar/Plugins/PluginsManifestStore.swift
@@ -1,0 +1,341 @@
+import Foundation
+import OSLog
+import Yams
+
+private let logger = Logger(subsystem: "com.statusbar", category: "PluginsManifestStore")
+
+// MARK: - PluginsManifest
+
+/// Top-level structure of plugins.yml. Declarative — the user's intent.
+struct PluginsManifest: Codable, Equatable {
+    var plugins: [PluginsManifestEntry]
+
+    init(plugins: [PluginsManifestEntry] = []) {
+        self.plugins = plugins
+    }
+
+    static let empty = Self()
+}
+
+// MARK: - PluginsManifestEntry
+
+/// One entry in plugins.yml.
+struct PluginsManifestEntry: Codable, Equatable {
+    /// `github:owner/repo` format.
+    var source: String
+    /// `"1.2.0"` (exact) or `"latest"`.
+    var version: String
+
+    /// True when both halves of `owner/repo` start alphanumeric and only use `[A-Za-z0-9._-]` —
+    /// matches `GitHubPluginInstaller.parseGitHubURL` and rejects `.`/`..` (path traversal).
+    private static func validateOwnerRepo(owner: Substring, repo: Substring) -> Bool {
+        let pattern = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
+        return owner.wholeMatch(of: pattern) != nil && repo.wholeMatch(of: pattern) != nil
+    }
+
+    /// Parse `github:owner/repo` into the (owner, repo) tuple. Returns nil for malformed entries.
+    func parseGitHubSource() -> (owner: String, repo: String)? {
+        guard source.hasPrefix("github:") else {
+            return nil
+        }
+        let path = source.dropFirst("github:".count)
+        let parts = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2, Self.validateOwnerRepo(owner: parts[0], repo: parts[1]) else {
+            return nil
+        }
+        return (String(parts[0]), String(parts[1]))
+    }
+
+    /// Convert a "https://github.com/owner/repo" URL into the `github:owner/repo` form used by plugins.yml.
+    /// Inverse of `parseGitHubSource()`.
+    static func source(fromGitHubURL url: String?) -> String? {
+        guard let url else {
+            return nil
+        }
+        let prefix = "https://github.com/"
+        guard url.hasPrefix(prefix) else {
+            return nil
+        }
+        let path = url.dropFirst(prefix.count)
+        let parts = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count >= 2, validateOwnerRepo(owner: parts[0], repo: parts[1]) else {
+            return nil
+        }
+        return "github:\(parts[0])/\(parts[1])"
+    }
+
+    var isLatest: Bool {
+        version == "latest"
+    }
+}
+
+// MARK: - PluginsLock
+
+/// Top-level structure of plugins-lock.yml. Resolved facts — re-installable snapshot.
+struct PluginsLock: Codable, Equatable {
+    /// Schema version for forward compatibility.
+    var lockfileVersion: Int
+    var plugins: [PluginsLockEntry]
+
+    init(lockfileVersion: Int = 1, plugins: [PluginsLockEntry] = []) {
+        self.lockfileVersion = lockfileVersion
+        self.plugins = plugins
+    }
+
+    static let empty = Self()
+}
+
+// MARK: - PluginsLockEntry
+
+/// One resolved entry in plugins-lock.yml.
+struct PluginsLockEntry: Codable, Equatable {
+    /// Matches the `source` in plugins.yml ("github:owner/repo").
+    var source: String
+    /// Concrete version that was resolved (no leading "v").
+    var resolvedVersion: String
+    /// Matching `DylibPluginManifest.id` (e.g. "com.example.weather").
+    var pluginID: String
+    /// Bundle directory name without the `.statusplugin` extension.
+    var bundleName: String
+    /// Download URL of the `.statusplugin.zip` asset (nil only after a migration before the first sync).
+    var assetURL: String?
+    /// SHA-256 of the downloaded zip (hex, lowercase). Nil only after migration.
+    var zipSHA256: String?
+    /// When this lock entry was resolved.
+    var resolvedAt: Date
+}
+
+// MARK: - PluginsManifestStore
+
+/// Persists plugins.yml and plugins-lock.yml under `~/.config/statusbar/` and watches
+/// the manifest for external edits. Sync logic lives in `PluginsManager` — this type
+/// is purely I/O + change notification.
+@MainActor
+@Observable
+final class PluginsManifestStore {
+    static let shared = PluginsManifestStore()
+
+    /// Last successfully loaded manifest. Defaults to empty when no file exists.
+    private(set) var currentManifest: PluginsManifest = .empty
+    /// Last successfully loaded lock. Defaults to empty when no file exists.
+    private(set) var currentLock: PluginsLock = .empty
+
+    let manifestURL: URL
+    let lockURL: URL
+
+    /// Manifest size cap — large enough for hundreds of entries, small enough to reject billion-laughs attacks.
+    private static let maxManifestFileSize: UInt64 = 262_144 // 256 KB
+
+    private var fsSource: DispatchSourceFileSystemObject?
+    private var fsDebounceTask: Task<Void, Never>?
+    private var lastKnownManifestModDate: Date?
+
+    private var lastWriteTime: Date?
+    private let writeGracePeriod: TimeInterval = 0.5
+
+    /// On-edit callback used by `PluginsManager` to surface a toast.
+    var onExternalEdit: (@MainActor () -> Void)?
+
+    private init() {
+        let configDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/statusbar", isDirectory: true)
+        manifestURL = configDir.appendingPathComponent("plugins.yml")
+        lockURL = configDir.appendingPathComponent("plugins-lock.yml")
+    }
+
+    /// Testable initializer accepting custom file URLs.
+    init(manifestURL: URL, lockURL: URL) {
+        self.manifestURL = manifestURL
+        self.lockURL = lockURL
+    }
+
+    // MARK: - Existence
+
+    var manifestExists: Bool {
+        FileManager.default.fileExists(atPath: manifestURL.path)
+    }
+
+    var lockExists: Bool {
+        FileManager.default.fileExists(atPath: lockURL.path)
+    }
+
+    // MARK: - Load
+
+    /// Initial load called once from bootstrap. Missing or unparseable files yield empty defaults so
+    /// the app can keep running; a malformed plugins.yml at startup is treated as no manifest at all
+    /// (the user can fix the file and trigger a sync).
+    func load() {
+        do {
+            currentManifest = try loadManifestFromDisk()
+        } catch {
+            logger.error("Failed to load plugins.yml — using empty manifest: \(error.localizedDescription)")
+            currentManifest = .empty
+        }
+        do {
+            currentLock = try loadLockFromDisk()
+        } catch {
+            logger.error("Failed to load plugins-lock.yml — using empty lock: \(error.localizedDescription)")
+            currentLock = .empty
+        }
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: manifestURL.path),
+           let modDate = attrs[.modificationDate] as? Date
+        {
+            lastKnownManifestModDate = modDate
+        }
+    }
+
+    /// Re-read plugins.yml after an external edit. Throws on parse error so the caller can preserve
+    /// the previously valid in-memory manifest rather than silently degrading to empty (which would
+    /// cause `sync()` to drift-uninstall every managed plugin).
+    func reload() throws {
+        currentManifest = try loadManifestFromDisk()
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: manifestURL.path),
+           let modDate = attrs[.modificationDate] as? Date
+        {
+            lastKnownManifestModDate = modDate
+        }
+    }
+
+    private func loadManifestFromDisk() throws -> PluginsManifest {
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            return .empty
+        }
+        let attrs = try FileManager.default.attributesOfItem(atPath: manifestURL.path)
+        let size = attrs[.size] as? UInt64 ?? 0
+        guard size <= Self.maxManifestFileSize else {
+            throw PluginsManifestError.fileTooLarge
+        }
+        let data = try Data(contentsOf: manifestURL)
+        let yaml = String(data: data, encoding: .utf8) ?? ""
+        if yaml.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return .empty
+        }
+        return try YAMLDecoder().decode(PluginsManifest.self, from: yaml)
+    }
+
+    private func loadLockFromDisk() throws -> PluginsLock {
+        guard FileManager.default.fileExists(atPath: lockURL.path) else {
+            return .empty
+        }
+        let data = try Data(contentsOf: lockURL)
+        let yaml = String(data: data, encoding: .utf8) ?? ""
+        if yaml.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return .empty
+        }
+        return try YAMLDecoder().decode(PluginsLock.self, from: yaml)
+    }
+
+    // MARK: - Save
+
+    /// Persist a manifest and update `currentManifest` on success.
+    func saveManifest(_ manifest: PluginsManifest) throws {
+        try ensureParentDirectoryExists(for: manifestURL)
+        lastWriteTime = Date()
+        let yaml = try YAMLEncoder().encode(manifest)
+        try Data(yaml.utf8).write(to: manifestURL, options: .atomic)
+        currentManifest = manifest
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: manifestURL.path),
+           let modDate = attrs[.modificationDate] as? Date
+        {
+            lastKnownManifestModDate = modDate
+        }
+    }
+
+    /// Persist a lock file and update `currentLock` on success.
+    func saveLock(_ lock: PluginsLock) throws {
+        try ensureParentDirectoryExists(for: lockURL)
+        lastWriteTime = Date()
+        let yaml = try YAMLEncoder().encode(lock)
+        try Data(yaml.utf8).write(to: lockURL, options: .atomic)
+        currentLock = lock
+    }
+
+    private func ensureParentDirectoryExists(for url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+    }
+
+    // MARK: - File watching
+
+    /// Start watching the config directory for external edits to plugins.yml.
+    func startWatching() {
+        guard fsSource == nil else {
+            return
+        }
+        let dirPath = manifestURL.deletingLastPathComponent().path
+        let fd = open(dirPath, O_EVTONLY)
+        guard fd >= 0 else {
+            logger.warning("Failed to open plugins config directory for watching")
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: .write,
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            Task { @MainActor in
+                self?.scheduleManifestCheck()
+            }
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        source.resume()
+        fsSource = source
+    }
+
+    func stopWatching() {
+        fsSource?.cancel()
+        fsSource = nil
+        fsDebounceTask?.cancel()
+        fsDebounceTask = nil
+    }
+
+    private func scheduleManifestCheck() {
+        fsDebounceTask?.cancel()
+        fsDebounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard !Task.isCancelled else {
+                return
+            }
+            self?.checkManifestChanged()
+        }
+    }
+
+    private func checkManifestChanged() {
+        // Ignore events shortly after our own writes (the grace window prevents echoes).
+        if let lastWrite = lastWriteTime, Date().timeIntervalSince(lastWrite) < writeGracePeriod {
+            return
+        }
+        let fm = FileManager.default
+        guard let attrs = try? fm.attributesOfItem(atPath: manifestURL.path),
+              let modDate = attrs[.modificationDate] as? Date
+        else {
+            return
+        }
+        if let lastMod = lastKnownManifestModDate, modDate <= lastMod {
+            return
+        }
+        lastKnownManifestModDate = modDate
+        onExternalEdit?()
+    }
+}
+
+// MARK: - PluginsManifestError
+
+enum PluginsManifestError: Error, LocalizedError {
+    case fileTooLarge
+    case invalidSource(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .fileTooLarge:
+            "plugins.yml exceeds the 256 KB size limit"
+        case let .invalidSource(source):
+            "Invalid source (expected github:owner/repo): \(source)"
+        }
+    }
+}

--- a/Sources/StatusBar/Preferences/Sections/PluginsSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/PluginsSection.swift
@@ -19,12 +19,14 @@ struct PluginsSection: View {
     @State private var needsRestart = false
     @State private var isCheckingUpdates = false
     @State private var availableUpdates: [GitHubPluginInstaller.UpdateInfo] = []
-    @State private var updateCheckDone = false
+    @State private var isSyncing = false
+    @State private var syncSummary: String?
     @State private var devPath: String = ""
     @State private var devPlugins: [DevPluginInfo] = []
     @State private var devError: String?
 
     var store: PluginStore = .shared
+    var manager: PluginsManager = .shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -65,7 +67,29 @@ struct PluginsSection: View {
                     .buttonStyle(.borderless)
                     .controlSize(.small)
                     .disabled(isCheckingUpdates || store.plugins.isEmpty)
+
+                    Button(action: syncManifest) {
+                        HStack(spacing: 4) {
+                            if isSyncing {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "arrow.triangle.2.circlepath")
+                            }
+                            Text(manager.isDirty ? "Sync (unsynced)" : "Sync Plugins")
+                        }
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .tint(manager.isDirty ? .orange : nil)
+                    .disabled(isSyncing || isInstalling)
                 }
+            }
+
+            if let syncSummary {
+                Label(syncSummary, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.caption)
             }
 
             // Add plugin
@@ -303,12 +327,10 @@ extension PluginsSection {
     private func checkForUpdates() {
         isCheckingUpdates = true
         availableUpdates = []
-        updateCheckDone = false
 
         Task {
             availableUpdates = await GitHubPluginInstaller.shared.checkForUpdates()
             isCheckingUpdates = false
-            updateCheckDone = true
         }
     }
 
@@ -319,7 +341,10 @@ extension PluginsSection {
 
         Task {
             do {
-                let record = try await GitHubPluginInstaller.shared.install(from: update.githubURL)
+                guard let source = PluginsManifestEntry.source(fromGitHubURL: update.githubURL) else {
+                    throw PluginsManagerError.unknownPlugin(update.pluginID)
+                }
+                let record = try await manager.add(source: source, version: "latest")
                 availableUpdates.removeAll { $0.pluginID == update.pluginID }
 
                 // Attempt hot-reload if the old plugin is loaded, otherwise cold-load
@@ -327,17 +352,14 @@ extension PluginsSection {
                 let registry = WidgetRegistry.shared
                 var reloaded = false
                 if loader.isLoaded(update.pluginID) {
-                    let bundleURL = FileManager.default.homeDirectoryForCurrentUser
-                        .appendingPathComponent(".config/statusbar/plugins")
-                        .appendingPathComponent("\(record.bundleName).statusplugin")
                     do {
-                        try loader.reload(pluginID: update.pluginID, bundleURL: bundleURL, into: registry)
+                        try loader.reload(
+                            pluginID: update.pluginID,
+                            bundleURL: pluginBundleURL(for: record),
+                            into: registry
+                        )
                         registry.finalizeRegistration()
-                        let newWidgetIDs = Set(loader.widgetIDs(for: record.id))
-                        let allWidgets = registry.leftWidgets + registry.centerWidgets + registry.rightWidgets
-                        for widget in allWidgets where newWidgetIDs.contains(widget.id) {
-                            widget.start()
-                        }
+                        startNewWidgets(for: record.id)
                         reloaded = true
                     } catch {
                         print("[PluginsSection] Hot-reload failed: \(error.localizedDescription)")
@@ -366,7 +388,9 @@ extension PluginsSection {
 
         Task {
             do {
-                let record = try await GitHubPluginInstaller.shared.install(from: githubURL)
+                let (owner, repo) = try GitHubPluginInstaller.shared.parseGitHubURL(githubURL)
+                let source = "github:\(owner)/\(repo)"
+                let record = try await manager.add(source: source, version: "latest")
                 githubURL = ""
 
                 // Try hot-loading the plugin immediately
@@ -383,17 +407,76 @@ extension PluginsSection {
         }
     }
 
-    /// Attempt to load the plugin without restart. Returns true on success.
-    private func hotLoadPlugin(_ record: InstalledPluginRecord) -> Bool {
-        let bundleURL = FileManager.default.homeDirectoryForCurrentUser
+    private func syncManifest() {
+        isSyncing = true
+        installError = nil
+        installSuccess = nil
+        syncSummary = nil
+
+        Task {
+            do {
+                let result = try await manager.sync(frozen: false)
+
+                // Hot-load any newly installed plugins so the bar updates without restart.
+                var anyHotLoadFailed = false
+                for pluginID in result.installed + result.updated {
+                    guard let record = store.record(forID: pluginID) else {
+                        anyHotLoadFailed = true
+                        continue
+                    }
+                    if DylibPluginLoader.shared.isLoaded(pluginID) {
+                        let bundleURL = pluginBundleURL(for: record)
+                        do {
+                            try DylibPluginLoader.shared.reload(
+                                pluginID: pluginID, bundleURL: bundleURL, into: WidgetRegistry.shared
+                            )
+                            WidgetRegistry.shared.finalizeRegistration()
+                            startNewWidgets(for: pluginID)
+                        } catch {
+                            anyHotLoadFailed = true
+                        }
+                    } else if !hotLoadPlugin(record) {
+                        anyHotLoadFailed = true
+                    }
+                }
+
+                if !result.uninstalled.isEmpty || anyHotLoadFailed {
+                    needsRestart = true
+                }
+
+                syncSummary = "\(result.summary)."
+                if result.hasErrors {
+                    installError = result.errors.map { "\($0.source): \($0.message)" }.joined(separator: "\n")
+                }
+            } catch {
+                installError = "Sync failed: \(error.localizedDescription)"
+            }
+            isSyncing = false
+        }
+    }
+
+    private func pluginBundleURL(for record: InstalledPluginRecord) -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/statusbar/plugins")
             .appendingPathComponent("\(record.bundleName).statusplugin")
+    }
 
+    private func startNewWidgets(for pluginID: String) {
+        let registry = WidgetRegistry.shared
+        let allWidgets = registry.leftWidgets + registry.centerWidgets + registry.rightWidgets
+        let pluginWidgetIDs = Set(DylibPluginLoader.shared.widgetIDs(for: pluginID))
+        for widget in allWidgets where pluginWidgetIDs.contains(widget.id) {
+            widget.start()
+        }
+    }
+
+    /// Attempt to load the plugin without restart. Returns true on success.
+    private func hotLoadPlugin(_ record: InstalledPluginRecord) -> Bool {
         let registry = WidgetRegistry.shared
         let existingIDs = Set(registry.layout.map(\.id))
 
         do {
-            try DylibPluginLoader.shared.load(bundleURL: bundleURL, into: registry)
+            try DylibPluginLoader.shared.load(bundleURL: pluginBundleURL(for: record), into: registry)
             registry.finalizeRegistration()
 
             // Start only the newly added widgets
@@ -428,11 +511,8 @@ extension PluginsSection {
         if enabled {
             // If not loaded yet, load from disk
             if !loader.isLoaded(plugin.id) {
-                let bundleURL = FileManager.default.homeDirectoryForCurrentUser
-                    .appendingPathComponent(".config/statusbar/plugins")
-                    .appendingPathComponent("\(plugin.bundleName).statusplugin")
                 do {
-                    try loader.load(bundleURL: bundleURL, into: registry)
+                    try loader.load(bundleURL: pluginBundleURL(for: plugin), into: registry)
                     registry.finalizeRegistration()
                 } catch {
                     print("[PluginsSection] Failed to load plugin: \(error.localizedDescription)")
@@ -458,8 +538,7 @@ extension PluginsSection {
 
     private func uninstallPlugin(id: String) {
         do {
-            DylibPluginLoader.shared.markForRemoval(pluginID: id, from: WidgetRegistry.shared)
-            try GitHubPluginInstaller.shared.uninstall(pluginID: id)
+            try manager.remove(pluginID: id)
             needsRestart = true
         } catch {
             installError = "Failed to uninstall: \(error.localizedDescription)"

--- a/Sources/statusbar-cli/Commands/PluginsCommand.swift
+++ b/Sources/statusbar-cli/Commands/PluginsCommand.swift
@@ -1,0 +1,75 @@
+import ArgumentParser
+import Foundation
+import StatusBarIPC
+
+// MARK: - PluginsCommand
+
+struct PluginsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "plugins",
+        abstract: "Manage plugins.yml / plugins-lock.yml",
+        subcommands: [PluginsSyncCommand.self, PluginsListCommand.self]
+    )
+}
+
+// MARK: - PluginsSyncCommand
+
+struct PluginsSyncCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "sync",
+        abstract: "Reconcile installed plugins with plugins.yml"
+    )
+
+    @Flag(name: .long, help: "Resolve from plugins-lock.yml only; do not contact GitHub")
+    var frozen: Bool = false
+
+    func run() throws {
+        let payload = try IPCClient.send(.pluginsSync(frozen: frozen))
+        guard case .ok = payload else {
+            throw ExitCode.failure
+        }
+        print("Sync started — check toasts for progress.")
+    }
+}
+
+// MARK: - PluginsListCommand
+
+struct PluginsListCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List plugin manifest entries with their lock state"
+    )
+
+    @OptionGroup var options: GlobalOptions
+
+    func run() throws {
+        let payload = try IPCClient.send(.pluginsList)
+        guard case let .pluginList(entries) = payload else {
+            throw ExitCode.failure
+        }
+
+        if options.json {
+            print(jsonOutput(entries))
+            return
+        }
+        if entries.isEmpty {
+            print("No plugins declared in plugins.yml")
+            return
+        }
+        for entry in entries {
+            let resolved = entry.resolvedVersion.map { "resolved=\($0)" } ?? "unresolved"
+            print("\(entry.source) [declared=\(entry.declaredVersion)] [\(resolved)]")
+        }
+    }
+
+    private func jsonOutput(_ entries: [PluginManifestEntryDTO]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(entries),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            return "[]"
+        }
+        return json
+    }
+}

--- a/Sources/statusbar-cli/SbarCLI.swift
+++ b/Sources/statusbar-cli/SbarCLI.swift
@@ -15,6 +15,7 @@ struct SbarCLI: ParsableCommand {
             SubscribeCommand.self,
             TriggerCommand.self,
             ToastCommand.self,
+            PluginsCommand.self,
         ]
     )
 }

--- a/Tests/StatusBarTests/PluginStorePersistenceTests.swift
+++ b/Tests/StatusBarTests/PluginStorePersistenceTests.swift
@@ -5,11 +5,9 @@ import Testing
 @MainActor
 struct PluginStorePersistenceTests {
     private func makeTempStore() -> (store: PluginStore, dir: URL, cleanup: @Sendable () -> Void) {
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-        let url = dir.appendingPathComponent("registry.json")
-        let cleanup: @Sendable () -> Void = { try? FileManager.default.removeItem(at: dir) }
-        return (PluginStore(registryURL: url), dir, cleanup)
+        let temp = PluginTestSupport.makeTempDir()
+        let store = PluginStore(registryURL: temp.url.appendingPathComponent("registry.json"))
+        return (store, temp.url, temp.cleanup)
     }
 
     private func makeRecord(
@@ -19,10 +17,10 @@ struct PluginStorePersistenceTests {
         enabled: Bool = true,
         isLocal: Bool = false
     ) -> InstalledPluginRecord {
-        InstalledPluginRecord(
+        PluginTestSupport.makeRecord(
             id: id, name: name, version: version,
-            githubURL: "https://github.com/test/\(id)",
-            bundleName: id, enabled: enabled, isLocal: isLocal
+            bundleName: id,
+            enabled: enabled, isLocal: isLocal
         )
     }
 

--- a/Tests/StatusBarTests/PluginTestSupport.swift
+++ b/Tests/StatusBarTests/PluginTestSupport.swift
@@ -1,0 +1,43 @@
+import Foundation
+@testable import StatusBar
+
+/// Shared test helpers for plugin-related test suites. Centralizing these avoids drift between
+/// `PluginStorePersistenceTests`, `PluginsManifestStoreTests`, and `PluginsManagerTests`.
+@MainActor
+enum PluginTestSupport {
+    struct TempDir {
+        let url: URL
+        let cleanup: @Sendable () -> Void
+    }
+
+    /// Create a fresh temporary directory plus a teardown closure.
+    static func makeTempDir() -> TempDir {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return TempDir(url: url) { try? FileManager.default.removeItem(at: url) }
+    }
+
+    /// Build an `InstalledPluginRecord` with sensible defaults for tests.
+    static func makeRecord(
+        id: String = "com.test.plugin",
+        name: String? = nil,
+        version: String = "1.0.0",
+        githubURL: String? = nil,
+        bundleName: String? = nil,
+        installedAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        enabled: Bool = true,
+        isLocal: Bool = false
+    ) -> InstalledPluginRecord {
+        InstalledPluginRecord(
+            id: id,
+            name: name ?? id,
+            version: version,
+            githubURL: githubURL ?? "https://github.com/test/\(id)",
+            bundleName: bundleName ?? id,
+            installedAt: installedAt,
+            enabled: enabled,
+            isLocal: isLocal
+        )
+    }
+}

--- a/Tests/StatusBarTests/PluginsListCommandHandlerTests.swift
+++ b/Tests/StatusBarTests/PluginsListCommandHandlerTests.swift
@@ -1,0 +1,24 @@
+@testable import StatusBar
+import StatusBarKit
+import Testing
+
+@MainActor
+struct PluginsListCommandHandlerTests {
+    private let handler = PluginsListCommandHandler()
+
+    @Test("List command returns pluginList payload")
+    func returnsPluginList() throws {
+        let payload = try handler.handle(.pluginsList)
+        guard case .pluginList = payload else {
+            Issue.record("Expected .pluginList payload, got \(payload)")
+            return
+        }
+    }
+
+    @Test("Wrong command case throws unknownCommand")
+    func wrongCommandCase() {
+        #expect(throws: IPCError.self) {
+            try handler.handle(.list)
+        }
+    }
+}

--- a/Tests/StatusBarTests/PluginsManagerTests.swift
+++ b/Tests/StatusBarTests/PluginsManagerTests.swift
@@ -1,0 +1,224 @@
+import Foundation
+@testable import StatusBar
+import Testing
+
+@MainActor
+struct PluginsManagerTests {
+    private struct TempEnv {
+        let manager: PluginsManager
+        let dir: URL
+        let store: PluginStore
+        let manifestStore: PluginsManifestStore
+        let cleanup: @Sendable () -> Void
+    }
+
+    private func makeTempEnv() -> TempEnv {
+        let temp = PluginTestSupport.makeTempDir()
+        let manifestStore = PluginsManifestStore(
+            manifestURL: temp.url.appendingPathComponent("plugins.yml"),
+            lockURL: temp.url.appendingPathComponent("plugins-lock.yml")
+        )
+        let pluginStore = PluginStore(registryURL: temp.url.appendingPathComponent("registry.json"))
+        let manager = PluginsManager(
+            manifestStore: manifestStore,
+            pluginStore: pluginStore,
+            installer: GitHubPluginInstaller.shared
+        )
+        return TempEnv(
+            manager: manager, dir: temp.url, store: pluginStore,
+            manifestStore: manifestStore, cleanup: temp.cleanup
+        )
+    }
+
+    private func makeRecord(
+        id: String,
+        version: String = "1.0.0",
+        githubURL: String? = "https://github.com/test/plugin",
+        isLocal: Bool = false
+    ) -> InstalledPluginRecord {
+        PluginTestSupport.makeRecord(id: id, version: version, githubURL: githubURL, isLocal: isLocal)
+    }
+
+    // MARK: - Migration
+
+    @Test("Migration generates plugins.yml + plugins-lock.yml from registry")
+    func migrationFromRegistry() throws {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manager = env.manager
+        let store = env.store
+        let manifestStore = env.manifestStore
+        try store.add(makeRecord(id: "com.test.a", githubURL: "https://github.com/user/repo-a"))
+        try store.add(makeRecord(id: "com.test.b", githubURL: "https://github.com/user/repo-b"))
+
+        try manager.migrateIfNeeded()
+
+        manifestStore.load()
+        #expect(manifestStore.currentManifest.plugins.count == 2)
+        #expect(manifestStore.currentManifest.plugins.contains { $0.source == "github:user/repo-a" })
+        #expect(manifestStore.currentManifest.plugins.contains { $0.source == "github:user/repo-b" })
+        #expect(manifestStore.currentLock.plugins.count == 2)
+    }
+
+    @Test("Migration excludes local plugins")
+    func migrationExcludesLocal() throws {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manager = env.manager
+        let store = env.store
+        let manifestStore = env.manifestStore
+        try store.add(makeRecord(
+            id: "com.test.local",
+            githubURL: nil,
+            isLocal: true
+        ))
+        try store.add(makeRecord(
+            id: "com.test.github",
+            githubURL: "https://github.com/user/plugin"
+        ))
+
+        try manager.migrateIfNeeded()
+
+        manifestStore.load()
+        #expect(manifestStore.currentManifest.plugins.count == 1)
+        #expect(manifestStore.currentManifest.plugins[0].source == "github:user/plugin")
+    }
+
+    @Test("Migration is a no-op when plugins.yml already exists")
+    func migrationSkippedWhenManifestExists() throws {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manager = env.manager
+        let store = env.store
+        let manifestStore = env.manifestStore
+        // User-created manifest is preserved.
+        let userManifest = PluginsManifest(plugins: [
+            PluginsManifestEntry(source: "github:user/manual", version: "1.0.0"),
+        ])
+        try manifestStore.saveManifest(userManifest)
+
+        try store.add(makeRecord(
+            id: "com.test.from-registry",
+            githubURL: "https://github.com/user/from-registry"
+        ))
+
+        try manager.migrateIfNeeded()
+
+        manifestStore.load()
+        #expect(manifestStore.currentManifest == userManifest)
+    }
+
+    @Test("Migration with no GitHub plugins is a no-op")
+    func migrationNoGitHubPlugins() throws {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        try env.store.add(makeRecord(id: "local", githubURL: nil, isLocal: true))
+
+        try env.manager.migrateIfNeeded()
+
+        // No manifest written
+        let manifestPath = env.dir.appendingPathComponent("plugins.yml").path
+        #expect(!FileManager.default.fileExists(atPath: manifestPath))
+    }
+
+    @Test("Migration version is normalized (no leading v)")
+    func migrationNormalizesVersion() throws {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manager = env.manager
+        let store = env.store
+        let manifestStore = env.manifestStore
+        try store.add(makeRecord(
+            id: "com.test.v",
+            version: "v1.2.3",
+            githubURL: "https://github.com/user/v-prefix"
+        ))
+
+        try manager.migrateIfNeeded()
+
+        manifestStore.load()
+        #expect(manifestStore.currentManifest.plugins[0].version == "1.2.3")
+        #expect(manifestStore.currentLock.plugins[0].resolvedVersion == "1.2.3")
+    }
+
+    // MARK: - PluginsManifestEntry.source(fromGitHubURL:)
+
+    @Test("source(fromGitHubURL:) parses canonical URL")
+    func sourceFromCanonicalURL() {
+        #expect(PluginsManifestEntry.source(fromGitHubURL: "https://github.com/user/repo") == "github:user/repo")
+    }
+
+    @Test("source(fromGitHubURL:) rejects unrelated URLs", arguments: [
+        nil,
+        "",
+        "https://example.com/user/repo",
+        "https://github.com/",
+        "https://github.com/just-owner",
+    ])
+    func sourceFromInvalidURL(url: String?) {
+        #expect(PluginsManifestEntry.source(fromGitHubURL: url) == nil)
+    }
+
+    // MARK: - manifestEntryDTOs
+
+    @Test("manifestEntryDTOs combines manifest with lock")
+    func manifestDTOs() throws {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manager = env.manager
+        let manifestStore = env.manifestStore
+        try manifestStore.saveManifest(PluginsManifest(plugins: [
+            PluginsManifestEntry(source: "github:user/a", version: "latest"),
+            PluginsManifestEntry(source: "github:user/b", version: "1.0.0"),
+        ]))
+        try manifestStore.saveLock(PluginsLock(plugins: [
+            PluginsLockEntry(
+                source: "github:user/a", resolvedVersion: "2.5.0",
+                pluginID: "com.user.a", bundleName: "A",
+                assetURL: "https://objects.githubusercontent.com/x",
+                zipSHA256: "abc",
+                resolvedAt: Date()
+            ),
+            // user/b is intentionally absent from the lock (unresolved).
+        ]))
+
+        let dtos = manager.manifestEntryDTOs()
+
+        #expect(dtos.count == 2)
+        let a = try #require(dtos.first { $0.source == "github:user/a" })
+        #expect(a.declaredVersion == "latest")
+        #expect(a.resolvedVersion == "2.5.0")
+        #expect(a.zipSHA256 == "abc")
+        #expect(a.pluginID == "com.user.a")
+
+        let b = try #require(dtos.first { $0.source == "github:user/b" })
+        #expect(b.declaredVersion == "1.0.0")
+        #expect(b.resolvedVersion == nil)
+        #expect(b.zipSHA256 == nil)
+        #expect(b.pluginID == nil)
+    }
+
+    // MARK: - remove guards
+
+    @Test("remove throws for unknown plugin ID")
+    func removeUnknown() {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manager = env.manager
+        #expect(throws: PluginsManagerError.self) {
+            try manager.remove(pluginID: "does-not-exist")
+        }
+    }
+
+    @Test("remove rejects local plugins")
+    func removeLocalRejected() throws {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manager = env.manager
+        let store = env.store
+        try store.add(makeRecord(id: "com.local", githubURL: nil, isLocal: true))
+        #expect(throws: PluginsManagerError.self) {
+            try manager.remove(pluginID: "com.local")
+        }
+    }
+}

--- a/Tests/StatusBarTests/PluginsManifestStoreTests.swift
+++ b/Tests/StatusBarTests/PluginsManifestStoreTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+@testable import StatusBar
+import Testing
+import Yams
+
+@MainActor
+struct PluginsManifestStoreTests {
+    private func makeTempStore() -> (store: PluginsManifestStore, dir: URL, cleanup: @Sendable () -> Void) {
+        let temp = PluginTestSupport.makeTempDir()
+        let store = PluginsManifestStore(
+            manifestURL: temp.url.appendingPathComponent("plugins.yml"),
+            lockURL: temp.url.appendingPathComponent("plugins-lock.yml")
+        )
+        return (store, temp.url, temp.cleanup)
+    }
+
+    // MARK: - Round-trip
+
+    @Test("PluginsManifest round-trips through YAML")
+    func manifestRoundTrip() throws {
+        let original = PluginsManifest(plugins: [
+            PluginsManifestEntry(source: "github:user/weather-plugin", version: "1.2.0"),
+            PluginsManifestEntry(source: "github:user/spotify", version: "latest"),
+        ])
+        let yaml = try YAMLEncoder().encode(original)
+        let decoded = try YAMLDecoder().decode(PluginsManifest.self, from: yaml)
+        #expect(decoded == original)
+    }
+
+    @Test("source(fromGitHubURL:) is the inverse of parseGitHubSource()")
+    func sourceRoundTrip() throws {
+        let original = "https://github.com/owner/repo"
+        let source = PluginsManifestEntry.source(fromGitHubURL: original)
+        #expect(source == "github:owner/repo")
+        let parsed = try PluginsManifestEntry(source: #require(source), version: "1.0.0").parseGitHubSource()
+        #expect(parsed?.owner == "owner")
+        #expect(parsed?.repo == "repo")
+    }
+
+    @Test("PluginsLock round-trips through YAML")
+    func lockRoundTrip() throws {
+        let resolvedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let original = PluginsLock(plugins: [
+            PluginsLockEntry(
+                source: "github:user/weather-plugin",
+                resolvedVersion: "1.2.0",
+                pluginID: "com.user.weather",
+                bundleName: "Weather",
+                assetURL: "https://objects.githubusercontent.com/abc",
+                zipSHA256: "deadbeef",
+                resolvedAt: resolvedAt
+            ),
+        ])
+        let yaml = try YAMLEncoder().encode(original)
+        let decoded = try YAMLDecoder().decode(PluginsLock.self, from: yaml)
+        #expect(decoded == original)
+    }
+
+    @Test("Lock entry round-trips even when assetURL/zipSHA256 are nil (post-migration state)")
+    func lockRoundTripUnresolved() throws {
+        let entry = PluginsLockEntry(
+            source: "github:user/x",
+            resolvedVersion: "0.1.0",
+            pluginID: "com.x",
+            bundleName: "X",
+            assetURL: nil,
+            zipSHA256: nil,
+            resolvedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let lock = PluginsLock(plugins: [entry])
+        let yaml = try YAMLEncoder().encode(lock)
+        let decoded = try YAMLDecoder().decode(PluginsLock.self, from: yaml)
+        #expect(decoded.plugins[0].assetURL == nil)
+        #expect(decoded.plugins[0].zipSHA256 == nil)
+    }
+
+    // MARK: - parseGitHubSource
+
+    @Test("parseGitHubSource accepts well-formed entries")
+    func parseGitHubSourceValid() {
+        let entry = PluginsManifestEntry(source: "github:owner/repo", version: "1.0.0")
+        let parsed = entry.parseGitHubSource()
+        #expect(parsed?.owner == "owner")
+        #expect(parsed?.repo == "repo")
+    }
+
+    @Test("parseGitHubSource rejects malformed entries", arguments: [
+        "owner/repo", // missing prefix
+        "github:", // empty path
+        "github:owner", // missing repo
+        "github:/repo", // missing owner
+        "github:owner/", // missing repo
+    ])
+    func parseGitHubSourceInvalid(source: String) {
+        let entry = PluginsManifestEntry(source: source, version: "1.0.0")
+        #expect(entry.parseGitHubSource() == nil)
+    }
+
+    // MARK: - Save / Load
+
+    @Test("Save then load yields the same manifest")
+    func saveLoadManifest() throws {
+        let (store, _, cleanup) = makeTempStore()
+        defer { cleanup() }
+        let manifest = PluginsManifest(plugins: [
+            PluginsManifestEntry(source: "github:a/b", version: "1.0.0"),
+        ])
+        try store.saveManifest(manifest)
+        store.load()
+        #expect(store.currentManifest == manifest)
+    }
+
+    @Test("Save then load yields the same lock")
+    func saveLoadLock() throws {
+        let (store, _, cleanup) = makeTempStore()
+        defer { cleanup() }
+        let lock = PluginsLock(plugins: [
+            PluginsLockEntry(
+                source: "github:a/b",
+                resolvedVersion: "1.0.0",
+                pluginID: "com.a.b",
+                bundleName: "B",
+                assetURL: "https://objects.githubusercontent.com/x",
+                zipSHA256: "deadbeef",
+                resolvedAt: Date(timeIntervalSince1970: 1_700_000_000)
+            ),
+        ])
+        try store.saveLock(lock)
+        store.load()
+        #expect(store.currentLock == lock)
+    }
+
+    @Test("Load with no files yields empty defaults")
+    func loadMissing() {
+        let (store, _, cleanup) = makeTempStore()
+        defer { cleanup() }
+        store.load()
+        #expect(store.currentManifest == .empty)
+        #expect(store.currentLock == .empty)
+        #expect(!store.manifestExists)
+    }
+
+    @Test("Empty manifest YAML loads as empty")
+    func loadEmptyManifest() throws {
+        let (store, dir, cleanup) = makeTempStore()
+        defer { cleanup() }
+        try Data("".utf8).write(to: dir.appendingPathComponent("plugins.yml"))
+        store.load()
+        #expect(store.currentManifest == .empty)
+    }
+
+    @Test("reload() throws on parse error so callers can preserve previous state")
+    func reloadThrowsOnParseError() throws {
+        let (store, dir, cleanup) = makeTempStore()
+        defer { cleanup() }
+        try Data("plugins: [not-a-list".utf8).write(to: dir.appendingPathComponent("plugins.yml"))
+        #expect(throws: (any Error).self) {
+            try store.reload()
+        }
+    }
+
+    @Test("Save creates parent directory if missing")
+    func saveCreatesDirectory() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // No mkdir; PluginsManifestStore should create it.
+        let store = PluginsManifestStore(
+            manifestURL: dir.appendingPathComponent("plugins.yml"),
+            lockURL: dir.appendingPathComponent("plugins-lock.yml")
+        )
+        try store.saveManifest(PluginsManifest(plugins: []))
+        #expect(FileManager.default.fileExists(atPath: dir.path))
+    }
+}

--- a/Tests/StatusBarTests/PluginsSyncCommandHandlerTests.swift
+++ b/Tests/StatusBarTests/PluginsSyncCommandHandlerTests.swift
@@ -1,0 +1,24 @@
+@testable import StatusBar
+import StatusBarKit
+import Testing
+
+@MainActor
+struct PluginsSyncCommandHandlerTests {
+    private let handler = PluginsSyncCommandHandler()
+
+    @Test("Sync command returns .ok immediately (work runs detached)")
+    func returnsOk() throws {
+        let payload = try handler.handle(.pluginsSync(frozen: false))
+        guard case .ok = payload else {
+            Issue.record("Expected .ok payload, got \(payload)")
+            return
+        }
+    }
+
+    @Test("Wrong command case throws unknownCommand")
+    func wrongCommandCase() {
+        #expect(throws: IPCError.self) {
+            try handler.handle(.list)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a declarative manifest (`plugins.yml`) and resolved-version lockfile (`plugins-lock.yml`) alongside the existing `registry.json`, so plugins can be managed via hand-editable YAML, the GUI, or the CLI, and so a plugin set can be reproduced on another machine with a single `sbar plugins sync --frozen` command.

## Changes

**Core model**
- `PluginsManifestStore` — YAML I/O + FS watch for `~/.config/statusbar/plugins.yml` and `plugins-lock.yml`. `reload()` throws so callers can preserve the previous in-memory manifest on parse error instead of treating a broken file as "no plugins declared" and uninstalling everything as drift.
- `PluginsManager` — orchestrates first-run migration (registry → manifest + lock), install, uninstall, drift removal, and full sync. Concurrent `sync()` callers are coalesced through a shared in-flight `Task`. Drift comparison is case-insensitive to match GitHub's behavior for owner/repo names.
- `GitHubPluginInstaller` — `install(from:version:)` gains an explicit version argument (`"1.2.0"` or `nil`/`"latest"`), computes the downloaded zip's SHA-256, and returns it via a new `InstallResult`. `installFromLock(...)` performs a frozen-mode restore by downloading from the lockfile's `assetURL` and verifying the recorded hash.

**GUI**
- Preferences > Plugins gains a **Sync Plugins** button (highlighted when the manifest has unsynced external edits) and routes Install / Uninstall through `PluginsManager` so manifest, lockfile, and registry stay aligned.

**IPC / CLI**
- New `IPCCommand.pluginsSync(frozen:)` and `IPCCommand.pluginsList` handlers. Sync acknowledges immediately and reports the outcome via toast.
- `sbar plugins sync [--frozen]` and `sbar plugins list [--json]` subcommands.

**Migration**
- On first launch with an existing `registry.json` and no `plugins.yml`, GitHub-installed plugins are auto-promoted to a generated `plugins.yml` + `plugins-lock.yml`. Local (`isLocal == true`) plugins are intentionally excluded. The lock's `assetURL` / `zipSHA256` are filled in on the next non-frozen sync.

**Tests**
- New suites for the manifest store, manager (migration, drift exclusion of local plugins, version normalization, DTO mapping, remove guards), and IPC handlers. `PluginTestSupport` consolidates the previously duplicated temp-dir / record-builder helpers used by three suites.

**Dependency**
- Bumps StatusBarKit `1.8.0` → `1.9.0` for the new IPC cases and `PluginManifestEntryDTO`.

## Notes

- A malformed `plugins.yml` during hot-reload no longer silently degrades to an empty manifest — `reload()` keeps the previous valid state and surfaces a warning toast. Without this guard, a single bad edit would cause the next sync to uninstall every declared plugin.
- `PluginsManager.add()` installs first and only writes `plugins.yml` once the install succeeds, so a network failure does not leave a poisoned manifest entry behind. `remove()` mirrors this: bundle removal runs before the in-memory teardown so a permission error is recoverable.
- The "Sync" button still drives hot-loading per plugin; new installs / updates without a successful hot-reload set `needsRestart`. Consolidating hot-reload into `PluginsManager` is a follow-up.

## Test plan

- [ ] `swift build`
- [ ] `swift test` (248 tests, 33 suites currently)
- [ ] Manual smoke: GUI install of a GitHub plugin produces a `plugins.yml` entry and a populated lock entry
- [ ] Manual smoke: edit `plugins.yml` externally → toast warns about unsynced changes → Sync Plugins applies them
- [ ] Manual smoke: `sbar plugins list` and `sbar plugins sync` reflect the current state
- [ ] Manual smoke: `sbar plugins sync --frozen` succeeds on a populated lockfile, fails clearly when entries lack `assetURL` / `zipSHA256` (e.g., immediately after first-run migration)