### PR TITLE
fix: keep onboarding page indicator centered across pages

### DIFF
--- a/Sources/StatusBar/Onboarding/OnboardingView.swift
+++ b/Sources/StatusBar/Onboarding/OnboardingView.swift
@@ -29,24 +29,14 @@ struct OnboardingView: View {
 
             // Navigation
             HStack {
-                if page != .welcome {
-                    Button("Back") {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            page = page.previous
-                        }
+                Button("Back") {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        page = page.previous
                     }
                 }
-
-                Spacer()
-
-                // Page indicator
-                HStack(spacing: 6) {
-                    ForEach(OnboardingPage.allCases) { p in
-                        Circle()
-                            .fill(p == page ? Color.accentColor : Color.secondary.opacity(0.3))
-                            .frame(width: 6, height: 6)
-                    }
-                }
+                .opacity(page == .welcome ? 0 : 1)
+                .disabled(page == .welcome)
+                .accessibilityHidden(page == .welcome)
 
                 Spacer()
 
@@ -63,6 +53,17 @@ struct OnboardingView: View {
                         }
                     }
                     .keyboardShortcut(.defaultAction)
+                }
+            }
+            // Page indicator — overlaid so it stays window-centered regardless
+            // of Back/Next button width changes between pages.
+            .overlay {
+                HStack(spacing: 6) {
+                    ForEach(OnboardingPage.allCases) { p in
+                        Circle()
+                            .fill(p == page ? Color.accentColor : Color.secondary.opacity(0.3))
+                            .frame(width: 6, height: 6)
+                    }
                 }
             }
             .padding(16)


### PR DESCRIPTION
## Summary

The dot indicator at the bottom of the onboarding view visibly shifted horizontally between pages. The old layout was `HStack(Back? | Spacer | Dots | Spacer | Next/GetStarted)`, but the Back button is hidden on the welcome page and the right-side button label changes from "Next" to "Get Started" on the final page. Both shifts unbalanced the two `Spacer()` instances and pulled the dots off-center.

## Changes

- Move the dot indicator into an `.overlay` on the button row so it stays window-centered regardless of button width.
- Always render the Back button; on the welcome page apply `.opacity(0).disabled(true).accessibilityHidden(true)` to reserve no visible space while keeping layout stable and avoiding a phantom "disabled Back" announcement to VoiceOver.

## Notes

- One-file change in `Sources/StatusBar/Onboarding/OnboardingView.swift`.
- No behavior change beyond the visual fix; navigation flow, animations, and copy are untouched.