### PR TITLE
feat: add Quit option to Apple menu

### DIFF
--- a/Sources/StatusBar/Widgets/AppleMenuWidget.swift
+++ b/Sources/StatusBar/Widgets/AppleMenuWidget.swift
@@ -177,6 +177,9 @@ struct AppleMenuPopupContent: View {
                     PopupRow(icon: "arrow.clockwise", label: "Reload") {
                         AppUpdateService.relaunchApp()
                     }
+                    PopupRow(icon: "power.circle", label: "Quit") {
+                        NSApp.terminate(nil)
+                    }
                 }
                 .padding(.horizontal, 6)
                 .padding(.bottom, 8)


### PR DESCRIPTION
## Summary
Add a Quit row to the Utilities section of the Apple menu popup so the app can be terminated directly from the status bar.

## Changes
- `AppleMenuWidget.swift`: new `PopupRow` (icon `power.circle`, label `Quit`) under Reload that calls `NSApp.terminate(nil)`.

## Notes
- No confirmation dialog — behaves like Cmd+Q.