### PR TITLE
feat: add display brightness widget

### DIFF
--- a/Sources/StatusBar/App/AppDelegate.swift
+++ b/Sources/StatusBar/App/AppDelegate.swift
@@ -88,6 +88,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         registry.register(CPUGraphWidget())
         registry.register(DiskUsageWidget())
         registry.register(BatteryWidget())
+        registry.register(BrightnessWidget())
         registry.register(VolumeWidget())
         registry.register(InputSourceWidget())
         registry.register(DateWidget())

--- a/Sources/StatusBar/Services/BrightnessService.swift
+++ b/Sources/StatusBar/Services/BrightnessService.swift
@@ -1,0 +1,127 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+// MARK: - ManagedDisplay
+
+struct ManagedDisplay: Identifiable, Hashable {
+    let id: CGDirectDisplayID
+    let name: String
+    var brightness: Float
+    let isBuiltin: Bool
+}
+
+// MARK: - DisplayServicesBindings
+
+/// Private framework binding loaded lazily via `dlopen`.
+/// No additional entitlement is required: the framework is system-signed
+/// and `disable-library-validation` already covers the dylib plugin loader.
+private enum DisplayServicesBindings {
+    typealias GetFn = @convention(c) (CGDirectDisplayID, UnsafeMutablePointer<Float>) -> Int32
+    typealias SetFn = @convention(c) (CGDirectDisplayID, Float) -> Int32
+
+    static let getBrightness: GetFn? = load("DisplayServicesGetBrightness")
+    static let setBrightness: SetFn? = load("DisplayServicesSetBrightness")
+
+    private static func load<T>(_ symbol: String) -> T? {
+        guard let handle = dlopen(
+            "/System/Library/PrivateFrameworks/DisplayServices.framework/DisplayServices",
+            RTLD_LAZY
+        ) else {
+            return nil
+        }
+        guard let sym = dlsym(handle, symbol) else {
+            return nil
+        }
+        return unsafeBitCast(sym, to: T.self)
+    }
+}
+
+// MARK: - BrightnessService
+
+@MainActor
+final class BrightnessService {
+    static let shared = BrightnessService()
+
+    private init() {}
+
+    /// Whether the underlying private framework loaded successfully.
+    var isAvailable: Bool {
+        DisplayServicesBindings.getBrightness != nil && DisplayServicesBindings.setBrightness != nil
+    }
+
+    /// Enumerate online displays whose brightness is controllable via `DisplayServices`.
+    ///
+    /// Phase 1 scope: Apple displays only. Third-party HDR monitors are excluded because
+    /// macOS 15+ exposes their SDR-peak slider through `DisplayServicesGetBrightness`,
+    /// which silently no-ops on the actual backlight. They would need DDC/CI support
+    /// to be controlled, which is a follow-up.
+    func enumerateDisplays() -> [ManagedDisplay] {
+        let maxDisplays: UInt32 = 16
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(maxDisplays))
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(maxDisplays, &ids, &count) == .success else {
+            return []
+        }
+
+        return ids.prefix(Int(count)).compactMap { id -> ManagedDisplay? in
+            // Skip the secondary side of a mirror pair — both IDs share the same
+            // physical panel, so we only need the primary.
+            if CGDisplayIsInMirrorSet(id) != 0, CGDisplayMirrorsDisplay(id) != 0 {
+                return nil
+            }
+
+            let isBuiltin = CGDisplayIsBuiltin(id) != 0
+            let isAppleVendor = CGDisplayVendorNumber(id) == appleVendorID
+            guard isBuiltin || isAppleVendor else {
+                return nil
+            }
+
+            guard let value = getBrightness(id) else {
+                return nil
+            }
+
+            return ManagedDisplay(
+                id: id,
+                name: localizedName(for: id),
+                brightness: value,
+                isBuiltin: isBuiltin
+            )
+        }
+    }
+
+    func getBrightness(_ id: CGDirectDisplayID) -> Float? {
+        guard let fn = DisplayServicesBindings.getBrightness else {
+            return nil
+        }
+        var value: Float = 0
+        guard fn(id, &value) == 0 else {
+            return nil
+        }
+        return value
+    }
+
+    @discardableResult
+    func setBrightness(_ value: Float, for id: CGDirectDisplayID) -> Bool {
+        guard let fn = DisplayServicesBindings.setBrightness else {
+            return false
+        }
+        let clamped = max(0, min(1, value))
+        return fn(id, clamped) == 0
+    }
+
+    // MARK: - Private
+
+    /// Apple's PNP vendor ID (`AAPL`). All Apple-built displays report this value.
+    private let appleVendorID: UInt32 = 1_552
+
+    private func localizedName(for id: CGDirectDisplayID) -> String {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        if let screen = NSScreen.screens.first(where: {
+            ($0.deviceDescription[key] as? CGDirectDisplayID) == id
+        }) {
+            return screen.localizedName
+        }
+        return "Display \(id)"
+    }
+}

--- a/Sources/StatusBar/Widgets/BrightnessWidget.swift
+++ b/Sources/StatusBar/Widgets/BrightnessWidget.swift
@@ -1,0 +1,318 @@
+import AppKit
+import Combine
+import CoreGraphics
+import StatusBarKit
+import SwiftUI
+
+// MARK: - BrightnessEvent
+
+enum BrightnessEvent {
+    static let changed = "brightness_changed"
+}
+
+extension IPCEventEnvelope {
+    static func brightnessChanged(displayID: CGDirectDisplayID, brightness: Float) -> Self {
+        IPCEventEnvelope(
+            event: BrightnessEvent.changed,
+            payload: .object([
+                "displayID": .number(Double(displayID)),
+                "brightness": .number(Double(brightness)),
+            ])
+        )
+    }
+}
+
+// MARK: - Shared helpers
+
+/// Threshold below which a brightness delta is considered noise.
+/// Sub-1% changes don't move the displayed integer percentage.
+private let brightnessEpsilon: Float = 0.005
+
+private func brightnessIconName(for value: Float) -> String {
+    switch value {
+    case ..<0.34: "sun.min"
+    case ..<0.67: "sun.max"
+    default: "sun.max.fill"
+    }
+}
+
+// MARK: - BrightnessWidget
+
+@MainActor
+@Observable
+final class BrightnessWidget: StatusBarWidget, EventEmitting {
+    let id = "brightness"
+    let position: WidgetPosition = .right
+    let updateInterval: TimeInterval? = 2.0
+    var sfSymbolName: String {
+        "sun.max"
+    }
+
+    private var displays: [ManagedDisplay] = []
+    private var timer: AnyCancellable?
+    private var screenObserver: NSObjectProtocol?
+    private var popupPanel: PopupPanel?
+    private var lastEmitted: [CGDirectDisplayID: Float] = [:]
+
+    private let service = BrightnessService.shared
+
+    func start() {
+        guard timer == nil, service.isAvailable, let interval = updateInterval else {
+            return
+        }
+        refreshDisplays()
+        timer = Timer.publish(every: interval, tolerance: interval * 0.1, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                self?.poll()
+            }
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.refreshDisplays()
+            }
+        }
+    }
+
+    func stop() {
+        timer?.cancel()
+        timer = nil
+        if let observer = screenObserver {
+            NotificationCenter.default.removeObserver(observer)
+            screenObserver = nil
+        }
+        popupPanel?.hidePopup()
+    }
+
+    func body() -> some View {
+        Group {
+            if displays.isEmpty {
+                EmptyView()
+            } else {
+                HStack(spacing: 2) {
+                    Image(systemName: brightnessIconName(for: barBrightness))
+                        .font(Theme.sfIconFont)
+                        .foregroundStyle(.primary)
+                        .frame(width: 18, alignment: .center)
+                    Text("\(percent(barBrightness))%")
+                        .font(Theme.labelFont)
+                        .monospacedDigit()
+                        .foregroundStyle(.primary)
+                        .fixedSize()
+                        .frame(width: 38, alignment: .trailing)
+                        .contentTransition(.numericText())
+                }
+                .padding(.horizontal, 4)
+                .contentShape(Rectangle())
+                .onTapGesture { [weak self] in
+                    self?.togglePopup()
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Brightness")
+                .accessibilityValue("\(percent(barBrightness))%")
+            }
+        }
+    }
+
+    // MARK: - Polling
+
+    private func refreshDisplays() {
+        let fresh = service.enumerateDisplays()
+        let topologyChanged = Set(displays.map(\.id)) != Set(fresh.map(\.id))
+        withAnimation(.numericTransition) {
+            displays = fresh
+        }
+        if topologyChanged {
+            lastEmitted = lastEmitted.filter { key, _ in fresh.contains { $0.id == key } }
+            if popupPanel?.isVisible == true {
+                refreshPopup()
+            }
+        }
+    }
+
+    private func poll() {
+        var changed = false
+        var updated = displays
+        for index in updated.indices {
+            guard let value = service.getBrightness(updated[index].id) else {
+                continue
+            }
+            if abs(updated[index].brightness - value) >= brightnessEpsilon {
+                updated[index].brightness = value
+                changed = true
+            }
+        }
+        guard changed else {
+            return
+        }
+        withAnimation(.numericTransition) {
+            displays = updated
+        }
+        emitChanges()
+        if popupPanel?.isVisible == true {
+            refreshPopup()
+        }
+    }
+
+    private func emitChanges() {
+        for display in displays {
+            emitIfChanged(displayID: display.id, value: display.brightness)
+        }
+    }
+
+    private func emitIfChanged(displayID: CGDirectDisplayID, value: Float) {
+        if let last = lastEmitted[displayID], abs(last - value) < brightnessEpsilon {
+            return
+        }
+        lastEmitted[displayID] = value
+        emit(.brightnessChanged(displayID: displayID, brightness: value))
+    }
+
+    // MARK: - Slider write-through
+
+    private func applyBrightness(_ value: Float, to displayID: CGDirectDisplayID) {
+        guard service.setBrightness(value, for: displayID) else {
+            return
+        }
+        if let index = displays.firstIndex(where: { $0.id == displayID }) {
+            displays[index].brightness = value
+        }
+        emitIfChanged(displayID: displayID, value: value)
+    }
+
+    // MARK: - Bar display
+
+    private var barBrightness: Float {
+        let mainID = CGMainDisplayID()
+        if let main = displays.first(where: { $0.id == mainID }) {
+            return main.brightness
+        }
+        return displays.first?.brightness ?? 0
+    }
+
+    private func percent(_ value: Float) -> Int {
+        Int((value * 100).rounded())
+    }
+
+    // MARK: - Popup
+
+    private func togglePopup() {
+        if popupPanel?.isVisible == true {
+            popupPanel?.hidePopup()
+        } else {
+            showPopup()
+        }
+    }
+
+    private func showPopup() {
+        if popupPanel == nil {
+            popupPanel = PopupPanel(contentRect: NSRect(x: 0, y: 0, width: 300, height: 140))
+        }
+        guard let (barFrame, screen) = PopupPanel.barTriggerFrame() else {
+            return
+        }
+        popupPanel?.showPopup(relativeTo: barFrame, on: screen, content: popupContent())
+    }
+
+    private func refreshPopup() {
+        guard let panel = popupPanel, panel.isVisible else {
+            return
+        }
+        panel.updateContent(popupContent())
+        panel.resizeToFitContent()
+    }
+
+    private func popupContent() -> some View {
+        BrightnessPopupContent(
+            displays: displays,
+            onChange: { [weak self] displayID, value in
+                self?.applyBrightness(value, to: displayID)
+            }
+        )
+    }
+}
+
+// MARK: - BrightnessPopupContent
+
+private struct BrightnessPopupContent: View {
+    let displays: [ManagedDisplay]
+    let onChange: (CGDirectDisplayID, Float) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            PopupSectionHeader("Brightness")
+
+            VStack(spacing: 10) {
+                ForEach(displays) { display in
+                    BrightnessDisplayRow(
+                        display: display,
+                        onChange: { onChange(display.id, $0) }
+                    )
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.bottom, 12)
+        }
+        .frame(width: 300)
+    }
+}
+
+// MARK: - BrightnessDisplayRow
+
+private struct BrightnessDisplayRow: View {
+    let display: ManagedDisplay
+    let onChange: (Float) -> Void
+
+    @State private var sliderValue: Double
+    @State private var isEditing: Bool = false
+
+    init(display: ManagedDisplay, onChange: @escaping (Float) -> Void) {
+        self.display = display
+        self.onChange = onChange
+        _sliderValue = State(initialValue: Double(display.brightness * 100))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(display.name)
+                .font(.system(size: 12, weight: .medium, design: .rounded))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            HStack(spacing: 10) {
+                Image(systemName: brightnessIconName(for: Float(sliderValue / 100)))
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .frame(width: 22, alignment: .center)
+                    .symbolRenderingMode(.hierarchical)
+
+                Slider(value: $sliderValue, in: 0 ... 100, step: 1) { editing in
+                    isEditing = editing
+                }
+                .tint(.blue)
+                .focusable(false)
+                .onChange(of: sliderValue) { _, newValue in
+                    onChange(Float(newValue / 100))
+                }
+
+                Text("\(Int(sliderValue))%")
+                    .font(.system(size: 12, weight: .semibold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(.primary)
+                    .frame(width: 36, alignment: .trailing)
+            }
+        }
+        .onChange(of: display.brightness) { _, newValue in
+            // External updates (e.g. F1/F2 polling tick) must not fight the user's drag.
+            guard !isEditing else {
+                return
+            }
+            let next = Double(newValue * 100)
+            if abs(sliderValue - next) >= 1 {
+                sliderValue = next
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new default widget that shows the main display's brightness on the bar and exposes a popup with per-display sliders so users can adjust each connected Apple display individually.

## Changes

- **`Services/BrightnessService.swift`**: Loads `DisplayServices.framework` via `dlopen` (no extra entitlement needed) and exposes display enumeration plus brightness get/set.
- **`Widgets/BrightnessWidget.swift`**: Status bar widget showing `🌞 N%` for the main display, with a Liquid Glass popup containing one slider per controllable display. Polls every 2 s to pick up external changes from F1/F2 and System Settings; subscribes to `didChangeScreenParametersNotification` for hot-plug. Emits `brightness_changed` over IPC.
- **`App/AppDelegate.swift`**: Registers `BrightnessWidget` as a default widget, slotted between Battery and Volume.

## Notes for reviewers

- **Phase 1 scope is Apple displays only** (built-in + vendor `1552`). Third-party HDR monitors are intentionally excluded because macOS 15+ exposes their SDR-peak slider through `DisplayServicesGetBrightness`, which silently no-ops the actual backlight. Supporting non-Apple monitors requires DDC/CI (`IOAVServiceWriteI2C`) and is a follow-up.
- If no controllable displays are detected, the widget renders `EmptyView()` and disappears from the bar.
- `brightness_changed` uses `emit` (not `emitRaw`) because `emitRaw` rate-limits per-event-name and would drop the 2nd…Nth display's event in a multi-display tick. This matches the `VolumeWidget` pattern for state-transition events.
- Slider drag is protected from polling overwrites via `Slider(onEditingChanged:)` + an `isEditing` flag.
- `start()` is idempotent (`guard timer == nil`), so the `screenObserver` cannot leak under repeated stop/start cycles from `WidgetRegistry`.

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 248 tests pass
- [x] `make run-dev` launches; `sbar list` shows `brightness right yes`
- [x] Manual: bar shows current main-display brightness, dragging the popup slider changes the screen, F1/F2 key updates the bar within ~2 s
- [x] Manual: plug/unplug an external Apple display and confirm rows appear/disappear in the popup