### PR TITLE
feat: support external displays in brightness widget

### DIFF
--- a/Sources/StatusBar/Services/BrightnessService.swift
+++ b/Sources/StatusBar/Services/BrightnessService.swift
@@ -1,6 +1,22 @@
 import AppKit
 import CoreGraphics
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.statusbar", category: "BrightnessService")
+
+// MARK: - DisplayKind
+
+enum DisplayKind: Hashable {
+    /// Built-in laptop / iMac panel — driven via DisplayServices SPI.
+    case builtin
+    /// External display whose brightness responds to DisplayServices
+    /// (Apple-branded externals, plus some HDR monitors that macOS controls
+    /// through the same SPI as the System Settings slider).
+    case displayServicesExternal
+    /// External display driven via DDC/CI over the CoreDisplay IOAVService SPI.
+    case ddc
+}
 
 // MARK: - ManagedDisplay
 
@@ -8,7 +24,7 @@ struct ManagedDisplay: Identifiable, Hashable {
     let id: CGDirectDisplayID
     let name: String
     var brightness: Float
-    let isBuiltin: Bool
+    let kind: DisplayKind
 }
 
 // MARK: - DisplayServicesBindings
@@ -45,52 +61,100 @@ final class BrightnessService {
 
     private init() {}
 
-    /// Whether the underlying private framework loaded successfully.
+    private let ddc = DDCService.shared
+
+    /// Whether at least one control path (DisplayServices or DDC) is available.
     var isAvailable: Bool {
-        DisplayServicesBindings.getBrightness != nil && DisplayServicesBindings.setBrightness != nil
+        DisplayServicesBindings.getBrightness != nil
     }
 
-    /// Enumerate online displays whose brightness is controllable via `DisplayServices`.
+    /// Enumerate online displays, classifying each by control path and seeding
+    /// the initial brightness value.
     ///
-    /// Phase 1 scope: Apple displays only. Third-party HDR monitors are excluded because
-    /// macOS 15+ exposes their SDR-peak slider through `DisplayServicesGetBrightness`,
-    /// which silently no-ops on the actual backlight. They would need DDC/CI support
-    /// to be controlled, which is a follow-up.
-    func enumerateDisplays() -> [ManagedDisplay] {
+    /// Strategy: try `DisplayServices` first for every display. If the SPI returns
+    /// a value, use it — this covers the built-in panel, Apple-branded externals,
+    /// and any third-party display whose brightness the System Settings slider
+    /// already drives. Only when DisplayServices declines do we fall back to DDC/CI.
+    func enumerateDisplays() async -> [ManagedDisplay] {
         let maxDisplays: UInt32 = 16
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(maxDisplays))
         var count: UInt32 = 0
         guard CGGetOnlineDisplayList(maxDisplays, &ids, &count) == .success else {
+            logger.warning("CGGetOnlineDisplayList failed")
             return []
         }
 
-        return ids.prefix(Int(count)).compactMap { id -> ManagedDisplay? in
+        var results: [ManagedDisplay] = []
+        var ddcCandidates: [CGDirectDisplayID] = []
+
+        for id in ids.prefix(Int(count)) {
             // Skip the secondary side of a mirror pair — both IDs share the same
             // physical panel, so we only need the primary.
             if CGDisplayIsInMirrorSet(id) != 0, CGDisplayMirrorsDisplay(id) != 0 {
-                return nil
+                continue
             }
 
             let isBuiltin = CGDisplayIsBuiltin(id) != 0
-            let isAppleVendor = CGDisplayVendorNumber(id) == appleVendorID
-            guard isBuiltin || isAppleVendor else {
-                return nil
-            }
 
-            guard let value = getBrightness(id) else {
-                return nil
+            if let value = getBrightnessViaDisplayServices(id) {
+                let kind: DisplayKind = isBuiltin ? .builtin : .displayServicesExternal
+                results.append(ManagedDisplay(
+                    id: id,
+                    name: localizedName(for: id),
+                    brightness: value,
+                    kind: kind
+                ))
+            } else {
+                ddcCandidates.append(id)
             }
+        }
 
-            return ManagedDisplay(
-                id: id,
-                name: localizedName(for: id),
-                brightness: value,
-                isBuiltin: isBuiltin
-            )
+        if !ddcCandidates.isEmpty {
+            let discovered = await ddc.discover(candidates: ddcCandidates)
+            for entry in discovered {
+                let name = localizedName(for: entry.id, fallback: entry.productName)
+                results.append(ManagedDisplay(
+                    id: entry.id,
+                    name: name,
+                    brightness: entry.brightness,
+                    kind: .ddc
+                ))
+            }
+        }
+        return results
+    }
+
+    func getBrightness(_ id: CGDirectDisplayID, kind: DisplayKind) async -> Float? {
+        switch kind {
+        case .builtin,
+             .displayServicesExternal:
+            getBrightnessViaDisplayServices(id)
+        case .ddc:
+            await ddc.getBrightness(id)
         }
     }
 
-    func getBrightness(_ id: CGDirectDisplayID) -> Float? {
+    @discardableResult
+    func setBrightness(_ value: Float, for id: CGDirectDisplayID, kind: DisplayKind) async -> Bool {
+        switch kind {
+        case .builtin,
+             .displayServicesExternal:
+            setBrightnessViaDisplayServices(value, for: id)
+        case .ddc:
+            await ddc.setBrightness(value, for: id)
+        }
+    }
+
+    /// Drop cached IOAVService handles. Call when the screen topology changes —
+    /// IOAVService is bound to a specific I2C transport and survives unplug only
+    /// in undefined ways.
+    func invalidateExternalCache() async {
+        await ddc.invalidateCache()
+    }
+
+    // MARK: - DisplayServices implementation
+
+    private func getBrightnessViaDisplayServices(_ id: CGDirectDisplayID) -> Float? {
         guard let fn = DisplayServicesBindings.getBrightness else {
             return nil
         }
@@ -101,8 +165,7 @@ final class BrightnessService {
         return value
     }
 
-    @discardableResult
-    func setBrightness(_ value: Float, for id: CGDirectDisplayID) -> Bool {
+    private func setBrightnessViaDisplayServices(_ value: Float, for id: CGDirectDisplayID) -> Bool {
         guard let fn = DisplayServicesBindings.setBrightness else {
             return false
         }
@@ -112,15 +175,17 @@ final class BrightnessService {
 
     // MARK: - Private
 
-    /// Apple's PNP vendor ID (`AAPL`). All Apple-built displays report this value.
-    private let appleVendorID: UInt32 = 1_552
-
-    private func localizedName(for id: CGDirectDisplayID) -> String {
+    private func localizedName(
+        for id: CGDirectDisplayID, fallback: String = ""
+    ) -> String {
         let key = NSDeviceDescriptionKey("NSScreenNumber")
         if let screen = NSScreen.screens.first(where: {
             ($0.deviceDescription[key] as? CGDirectDisplayID) == id
         }) {
             return screen.localizedName
+        }
+        if !fallback.isEmpty {
+            return fallback
         }
         return "Display \(id)"
     }

--- a/Sources/StatusBar/Services/DDCService.swift
+++ b/Sources/StatusBar/Services/DDCService.swift
@@ -1,0 +1,489 @@
+import CoreGraphics
+import Foundation
+import IOKit
+import IOKit.graphics
+import os
+
+private let logger = Logger(subsystem: "com.statusbar", category: "DDCService")
+
+// MARK: - Private symbol bindings
+
+/// Opaque AVService reference. Treated as a CF type so ARC handles retain/release.
+typealias IOAVService = CFTypeRef
+
+private enum CoreDisplayBindings {
+    typealias CreateWithServiceFn = @convention(c) (
+        CFAllocator?, io_service_t
+    ) -> Unmanaged<CFTypeRef>?
+    typealias WriteI2CFn = @convention(c) (
+        CFTypeRef, UInt32, UInt32, UnsafePointer<UInt8>, UInt32
+    ) -> Int32
+    typealias ReadI2CFn = @convention(c) (
+        CFTypeRef, UInt32, UInt32, UnsafeMutablePointer<UInt8>, UInt32
+    ) -> Int32
+    typealias CreateInfoDictFn = @convention(c) (CGDirectDisplayID) -> Unmanaged<CFDictionary>?
+
+    static let createWithService: CreateWithServiceFn? = load("IOAVServiceCreateWithService")
+    static let writeI2C: WriteI2CFn? = load("IOAVServiceWriteI2C")
+    static let readI2C: ReadI2CFn? = load("IOAVServiceReadI2C")
+    static let createInfoDict: CreateInfoDictFn? = load("CoreDisplay_DisplayCreateInfoDictionary")
+
+    // dlopen handle is opened once at process start and never reassigned, so the
+    // pointer is safe to share across actors despite the raw type being non-Sendable.
+    nonisolated(unsafe) private static let handle: UnsafeMutableRawPointer? = {
+        // CoreDisplay is technically a public framework but the IOAVService SPI
+        // is unexported. dlopen + dlsym is covered by disable-library-validation.
+        let candidates = [
+            "/System/Library/Frameworks/CoreDisplay.framework/CoreDisplay",
+            "/System/Library/PrivateFrameworks/CoreDisplay.framework/CoreDisplay",
+        ]
+        for path in candidates {
+            if let opened = dlopen(path, RTLD_LAZY) {
+                return opened
+            }
+        }
+        return nil
+    }()
+
+    private static func load<T>(_ symbol: String) -> T? {
+        guard let handle, let sym = dlsym(handle, symbol) else {
+            return nil
+        }
+        return unsafeBitCast(sym, to: T.self)
+    }
+}
+
+// MARK: - DDC packet constants
+
+private let ddcDisplayAddress: UInt8 = 0x37
+private let ddcDataAddress: UInt8 = 0x51
+private let vcpBrightness: UInt8 = 0x10
+
+// MARK: - DDCService
+
+/// Talks DDC/CI to external monitors via the CoreDisplay IOAVService SPI.
+///
+/// Apple Silicon only: the I2C transport on Intel Macs goes through
+/// `IOFramebuffer` instead of `IOAVService` and is not covered here.
+actor DDCService {
+    static let shared = DDCService()
+
+    private var displays: [CGDirectDisplayID: Entry] = [:]
+
+    private struct Entry {
+        let service: IOAVService
+        var vcpMax: UInt16
+        var lastWriteAt: ContinuousClock.Instant?
+    }
+
+    struct Discovered: Sendable {
+        let id: CGDirectDisplayID
+        let brightness: Float
+        let vcpMax: UInt16
+        let productName: String
+    }
+
+    var isAvailable: Bool {
+        CoreDisplayBindings.createWithService != nil
+            && CoreDisplayBindings.writeI2C != nil
+            && CoreDisplayBindings.readI2C != nil
+    }
+
+    /// Drop all cached IOAVService handles. Call when the display topology changes
+    /// (NSApplication.didChangeScreenParametersNotification) since hot-unplug
+    /// invalidates the underlying I2C transport.
+    func invalidateCache() {
+        displays.removeAll()
+    }
+
+    /// Discover DDC-capable external displays among the given CG display IDs.
+    /// Performs an initial brightness GET; displays that don't reply are excluded.
+    func discover(candidates: [CGDirectDisplayID]) -> [Discovered] {
+        guard isAvailable else {
+            logger.warning(
+                """
+                DDC unavailable — CoreDisplay symbol load failed \
+                (createWithService=\(CoreDisplayBindings.createWithService != nil), \
+                writeI2C=\(CoreDisplayBindings.writeI2C != nil), \
+                readI2C=\(CoreDisplayBindings.readI2C != nil))
+                """
+            )
+            return []
+        }
+        displays.removeAll()
+
+        let scanned = scanIORegistry()
+        let matches = matchServices(scanned, to: candidates)
+
+        var found: [Discovered] = []
+        for match in matches {
+            guard let result = readVCP(service: match.service, vcp: vcpBrightness) else {
+                logger.warning(
+                    "DDC VCP 0x10 GET failed for display \(match.displayID) (\(match.productName))"
+                )
+                continue
+            }
+            let vcpMax = max(result.max, 1)
+            let entry = Entry(service: match.service, vcpMax: vcpMax, lastWriteAt: nil)
+            displays[match.displayID] = entry
+            let brightness = min(1, Float(result.current) / Float(vcpMax))
+            found.append(
+                Discovered(
+                    id: match.displayID,
+                    brightness: brightness,
+                    vcpMax: vcpMax,
+                    productName: match.productName
+                )
+            )
+        }
+        return found
+    }
+
+    func getBrightness(_ id: CGDirectDisplayID) -> Float? {
+        guard let entry = displays[id] else {
+            return nil
+        }
+        // Skip a poll read while a write is still settling. DDC writes can take
+        // 100ms+ to propagate and reading in that window often returns stale or
+        // corrupt values.
+        if let lastWrite = entry.lastWriteAt,
+           lastWrite.duration(to: .now) < .milliseconds(250)
+        {
+            return nil
+        }
+        guard let result = readVCP(service: entry.service, vcp: vcpBrightness) else {
+            return nil
+        }
+        return min(1, Float(result.current) / Float(entry.vcpMax))
+    }
+
+    @discardableResult
+    func setBrightness(_ value: Float, for id: CGDirectDisplayID) -> Bool {
+        guard var entry = displays[id] else {
+            return false
+        }
+        let clamped = max(0, min(1, value))
+        let scaled = UInt16((clamped * Float(entry.vcpMax)).rounded())
+        guard writeVCP(service: entry.service, vcp: vcpBrightness, value: scaled) else {
+            return false
+        }
+        entry.lastWriteAt = .now
+        displays[id] = entry
+        return true
+    }
+
+    // MARK: - DDC I/O
+
+    private func readVCP(service: IOAVService, vcp: UInt8) -> (current: UInt16, max: UInt16)? {
+        var send: [UInt8] = [0x01, vcp]
+        var reply = [UInt8](repeating: 0, count: 11)
+        guard performDDC(service: service, send: &send, reply: &reply) else {
+            return nil
+        }
+        let maxValue = UInt16(reply[6]) << 8 | UInt16(reply[7])
+        let current = UInt16(reply[8]) << 8 | UInt16(reply[9])
+        return (current, maxValue)
+    }
+
+    private func writeVCP(service: IOAVService, vcp: UInt8, value: UInt16) -> Bool {
+        var send: [UInt8] = [0x03, vcp, UInt8(value >> 8), UInt8(value & 0xFF)]
+        var reply: [UInt8] = []
+        return performDDC(service: service, send: &send, reply: &reply)
+    }
+
+    /// MCCS/DDC packet format:
+    ///   [0x80 | (payload_len + 1), payload_len, ...payload, checksum]
+    /// Checksum seed is `(displayAddress << 1) ^ dataAddress` for multi-byte sends
+    /// (write or read-request) and `displayAddress << 1` for single-byte sends.
+    /// Read reply checksum seed is 0x50 — see MonitorControl Arm64DDC.swift.
+    private func performDDC(
+        service: IOAVService,
+        send: inout [UInt8],
+        reply: inout [UInt8]
+    ) -> Bool {
+        guard let write = CoreDisplayBindings.writeI2C else {
+            return false
+        }
+        var packet: [UInt8] = [UInt8(0x80 | (send.count + 1)), UInt8(send.count)] + send + [0]
+        let seed = send.count == 1
+            ? ddcDisplayAddress << 1
+            : (ddcDisplayAddress << 1) ^ ddcDataAddress
+        packet[packet.count - 1] = checksum(seed: seed, bytes: packet, end: packet.count - 2)
+
+        let maxAttempts = 5
+        for _ in 0 ..< maxAttempts {
+            usleep(10_000)
+            var success = packet.withUnsafeBufferPointer { buf -> Bool in
+                guard let base = buf.baseAddress else {
+                    return false
+                }
+                return write(
+                    service, UInt32(ddcDisplayAddress), UInt32(ddcDataAddress),
+                    base, UInt32(buf.count)
+                ) == 0
+            }
+            if !reply.isEmpty, success, let read = CoreDisplayBindings.readI2C {
+                usleep(50_000)
+                let readOK = reply.withUnsafeMutableBufferPointer { buf -> Bool in
+                    guard let base = buf.baseAddress else {
+                        return false
+                    }
+                    return read(service, UInt32(ddcDisplayAddress), 0, base, UInt32(buf.count)) == 0
+                }
+                if readOK {
+                    let want = checksum(seed: 0x50, bytes: reply, end: reply.count - 2)
+                    success = want == reply[reply.count - 1]
+                } else {
+                    success = false
+                }
+            }
+            if success {
+                return true
+            }
+            usleep(20_000)
+        }
+        return false
+    }
+
+    private func checksum(seed: UInt8, bytes: [UInt8], end: Int) -> UInt8 {
+        var chk = seed
+        for index in 0 ... end {
+            chk ^= bytes[index]
+        }
+        return chk
+    }
+
+    // MARK: - IORegistry scan + matching
+
+    private struct ScannedEntry {
+        let edidUUID: String
+        let location: String
+        let manufacturerID: String
+        let productName: String
+        let serialNumber: Int64
+        let alphanumericSerial: String
+        let serviceLocation: Int
+        let service: IOAVService
+    }
+
+    private struct Match {
+        let displayID: CGDirectDisplayID
+        let service: IOAVService
+        let productName: String
+    }
+
+    /// Walk IOService and pair each framebuffer (AppleCLCD2 / IOMobileFramebufferShim)
+    /// with the following external DCPAVServiceProxy.
+    private func scanIORegistry() -> [ScannedEntry] {
+        guard let createAV = CoreDisplayBindings.createWithService else {
+            return []
+        }
+        let root = IORegistryGetRootEntry(kIOMainPortDefault)
+        defer { IOObjectRelease(root) }
+
+        var iterator: io_iterator_t = 0
+        guard IORegistryEntryCreateIterator(
+            root, "IOService", IOOptionBits(kIORegistryIterateRecursively), &iterator
+        ) == KERN_SUCCESS else {
+            return []
+        }
+        defer { IOObjectRelease(iterator) }
+
+        var current = FramebufferProps()
+        var entries: [ScannedEntry] = []
+        var serviceLocation = 0
+        let frameBufferNames = ["AppleCLCD2", "IOMobileFramebufferShim"]
+
+        while case let next = IOIteratorNext(iterator), next != IO_OBJECT_NULL {
+            defer { IOObjectRelease(next) }
+
+            var nameBuffer = [CChar](repeating: 0, count: 128)
+            guard IORegistryEntryGetName(next, &nameBuffer) == KERN_SUCCESS else {
+                continue
+            }
+            let name = nameBuffer.withUnsafeBufferPointer { buf -> String in
+                guard let base = buf.baseAddress else {
+                    return ""
+                }
+                return String(cString: base)
+            }
+
+            if frameBufferNames.contains(where: { name.contains($0) }) {
+                current = readFramebufferProps(entry: next)
+                serviceLocation += 1
+                current.serviceLocation = serviceLocation
+            } else if name.contains("DCPAVServiceProxy") {
+                guard let location = stringProperty(of: next, key: "Location"),
+                      location == "External",
+                      let avRef = createAV(kCFAllocatorDefault, next)?.takeRetainedValue()
+                else {
+                    continue
+                }
+                entries.append(ScannedEntry(
+                    edidUUID: current.edidUUID,
+                    location: location,
+                    manufacturerID: current.manufacturerID,
+                    productName: current.productName,
+                    serialNumber: current.serialNumber,
+                    alphanumericSerial: current.alphanumericSerial,
+                    serviceLocation: current.serviceLocation,
+                    service: avRef
+                ))
+            }
+        }
+        return entries
+    }
+
+    private struct FramebufferProps {
+        var edidUUID: String = ""
+        var manufacturerID: String = ""
+        var productName: String = ""
+        var serialNumber: Int64 = 0
+        var alphanumericSerial: String = ""
+        var serviceLocation: Int = 0
+    }
+
+    private func readFramebufferProps(entry: io_service_t) -> FramebufferProps {
+        var props = FramebufferProps()
+        if let uuid = stringProperty(of: entry, key: "EDID UUID") {
+            props.edidUUID = uuid
+        }
+        if let displayAttrs = dictProperty(of: entry, key: "DisplayAttributes"),
+           let productAttrs = displayAttrs["ProductAttributes"] as? [String: Any]
+        {
+            props.manufacturerID = (productAttrs["ManufacturerID"] as? String) ?? ""
+            props.productName = (productAttrs["ProductName"] as? String) ?? ""
+            props.serialNumber = (productAttrs["SerialNumber"] as? Int64) ?? 0
+            props.alphanumericSerial = (productAttrs["AlphanumericSerialNumber"] as? String) ?? ""
+        }
+        return props
+    }
+
+    private func stringProperty(of entry: io_service_t, key: String) -> String? {
+        guard let prop = IORegistryEntryCreateCFProperty(
+            entry, key as CFString, kCFAllocatorDefault,
+            IOOptionBits(kIORegistryIterateRecursively)
+        ) else {
+            return nil
+        }
+        return prop.takeRetainedValue() as? String
+    }
+
+    private func dictProperty(of entry: io_service_t, key: String) -> [String: Any]? {
+        guard let prop = IORegistryEntryCreateCFProperty(
+            entry, key as CFString, kCFAllocatorDefault,
+            IOOptionBits(kIORegistryIterateRecursively)
+        ) else {
+            return nil
+        }
+        return prop.takeRetainedValue() as? [String: Any]
+    }
+
+    /// Score-based matching adapted from MonitorControl Arm64DDC.swift.
+    /// EDID UUID slices encode vendor/product/manufacture date/image size — we
+    /// compare those against `CoreDisplay_DisplayCreateInfoDictionary`. Serial
+    /// numbers from the registry rarely match the CG-reported value, but contribute
+    /// when they do. Service location is used as the final tiebreaker so identical
+    /// monitors on different ports don't collide.
+    private func matchServices(
+        _ scanned: [ScannedEntry], to candidates: [CGDirectDisplayID]
+    ) -> [Match] {
+        var scored: [Int: [(displayID: CGDirectDisplayID, entry: ScannedEntry)]] = [:]
+        for displayID in candidates {
+            for entry in scanned {
+                let score = matchScore(displayID: displayID, entry: entry)
+                scored[score, default: []].append((displayID, entry))
+            }
+        }
+        var takenDisplays = Set<CGDirectDisplayID>()
+        var takenLocations = Set<Int>()
+        var results: [Match] = []
+        for score in stride(from: 20, through: 1, by: -1) {
+            guard let bucket = scored[score] else {
+                continue
+            }
+            for candidate in bucket {
+                if takenDisplays.contains(candidate.displayID)
+                    || takenLocations.contains(candidate.entry.serviceLocation)
+                {
+                    continue
+                }
+                takenDisplays.insert(candidate.displayID)
+                takenLocations.insert(candidate.entry.serviceLocation)
+                results.append(Match(
+                    displayID: candidate.displayID,
+                    service: candidate.entry.service,
+                    productName: candidate.entry.productName
+                ))
+            }
+        }
+        return results
+    }
+
+    private func matchScore(displayID: CGDirectDisplayID, entry: ScannedEntry) -> Int {
+        guard let createInfo = CoreDisplayBindings.createInfoDict,
+              let info = createInfo(displayID)?.takeRetainedValue() as NSDictionary?
+        else {
+            return 0
+        }
+        var score = 0
+
+        if let vendor = info[kDisplayVendorID] as? Int64,
+           let product = info[kDisplayProductID] as? Int64,
+           let week = info[kDisplayWeekOfManufacture] as? Int64,
+           let year = info[kDisplayYearOfManufacture] as? Int64,
+           let vSize = info[kDisplayVerticalImageSize] as? Int64,
+           let hSize = info[kDisplayHorizontalImageSize] as? Int64
+        {
+            let edid = entry.edidUUID
+            let probes: [(offset: Int, expected: String)] = [
+                (0, hex16(vendor)),
+                (4, hex16le(product)),
+                (19, hex8(week) + hex8(year - 1990)),
+                (30, hex8(hSize / 10) + hex8(vSize / 10)),
+            ]
+            for probe in probes where probe.expected != "0000" {
+                let endIndex = probe.offset + 4
+                guard edid.count >= endIndex else {
+                    continue
+                }
+                let start = edid.index(edid.startIndex, offsetBy: probe.offset)
+                let end = edid.index(edid.startIndex, offsetBy: endIndex)
+                if String(edid[start ..< end]).uppercased() == probe.expected {
+                    score += 1
+                }
+            }
+        }
+
+        if let serial = info[kDisplaySerialNumber] as? Int64,
+           serial != 0, entry.serialNumber == serial
+        {
+            score += 1
+        }
+        if let nameMap = info["DisplayProductName"] as? [String: String],
+           let name = nameMap["en_US"] ?? nameMap.first?.value,
+           !entry.productName.isEmpty,
+           name.lowercased() == entry.productName.lowercased()
+        {
+            score += 1
+        }
+        return score
+    }
+
+    private func hex16(_ value: Int64) -> String {
+        let bounded = UInt16(max(0, min(value, 0xFFFF)))
+        return String(format: "%04X", bounded)
+    }
+
+    private func hex16le(_ value: Int64) -> String {
+        let bounded = UInt16(max(0, min(value, 0xFFFF)))
+        let lo = UInt8(bounded & 0xFF)
+        let hi = UInt8((bounded >> 8) & 0xFF)
+        return String(format: "%02X%02X", lo, hi)
+    }
+
+    private func hex8(_ value: Int64) -> String {
+        let bounded = UInt8(max(0, min(value, 0xFF)))
+        return String(format: "%02X", bounded)
+    }
+}

--- a/Sources/StatusBar/Services/DDCService.swift
+++ b/Sources/StatusBar/Services/DDCService.swift
@@ -11,6 +11,8 @@ private let logger = Logger(subsystem: "com.statusbar", category: "DDCService")
 /// Opaque AVService reference. Treated as a CF type so ARC handles retain/release.
 typealias IOAVService = CFTypeRef
 
+// MARK: - CoreDisplayBindings
+
 private enum CoreDisplayBindings {
     typealias CreateWithServiceFn = @convention(c) (
         CFAllocator?, io_service_t
@@ -28,8 +30,8 @@ private enum CoreDisplayBindings {
     static let readI2C: ReadI2CFn? = load("IOAVServiceReadI2C")
     static let createInfoDict: CreateInfoDictFn? = load("CoreDisplay_DisplayCreateInfoDictionary")
 
-    // dlopen handle is opened once at process start and never reassigned, so the
-    // pointer is safe to share across actors despite the raw type being non-Sendable.
+    /// dlopen handle is opened once at process start and never reassigned, so the
+    /// pointer is safe to share across actors despite the raw type being non-Sendable.
     nonisolated(unsafe) private static let handle: UnsafeMutableRawPointer? = {
         // CoreDisplay is technically a public framework but the IOAVService SPI
         // is unexported. dlopen + dlsym is covered by disable-library-validation.
@@ -76,7 +78,7 @@ actor DDCService {
         var lastWriteAt: ContinuousClock.Instant?
     }
 
-    struct Discovered: Sendable {
+    struct Discovered {
         let id: CGDirectDisplayID
         let brightness: Float
         let vcpMax: UInt16
@@ -205,9 +207,10 @@ actor DDCService {
             return false
         }
         var packet: [UInt8] = [UInt8(0x80 | (send.count + 1)), UInt8(send.count)] + send + [0]
-        let seed = send.count == 1
-            ? ddcDisplayAddress << 1
-            : (ddcDisplayAddress << 1) ^ ddcDataAddress
+        let displayWriteAddress = ddcDisplayAddress << 1
+        let seed: UInt8 = send.count == 1
+            ? displayWriteAddress
+            : displayWriteAddress ^ ddcDataAddress
         packet[packet.count - 1] = checksum(seed: seed, bytes: packet, end: packet.count - 2)
 
         let maxAttempts = 5
@@ -439,7 +442,7 @@ actor DDCService {
             let probes: [(offset: Int, expected: String)] = [
                 (0, hex16(vendor)),
                 (4, hex16le(product)),
-                (19, hex8(week) + hex8(year - 1990)),
+                (19, hex8(week) + hex8(year - 1_990)),
                 (30, hex8(hSize / 10) + hex8(vSize / 10)),
             ]
             for probe in probes where probe.expected != "0000" {

--- a/Sources/StatusBar/Widgets/BrightnessWidget.swift
+++ b/Sources/StatusBar/Widgets/BrightnessWidget.swift
@@ -28,12 +28,21 @@ extension IPCEventEnvelope {
 /// Sub-1% changes don't move the displayed integer percentage.
 private let brightnessEpsilon: Float = 0.005
 
+/// Throttle window for DDC writes during slider drag. DDC writes take 30-80ms
+/// per packet; without coalescing, a fast drag overruns the I2C bus and the
+/// monitor visibly lags. 40ms still feels live to the user.
+private let ddcWriteDebounce: Duration = .milliseconds(40)
+
 private func brightnessIconName(for value: Float) -> String {
     switch value {
     case ..<0.34: "sun.min"
     case ..<0.67: "sun.max"
     default: "sun.max.fill"
     }
+}
+
+private func brightnessPercent(_ value: Float) -> Int {
+    Int((value * 100).rounded())
 }
 
 // MARK: - BrightnessWidget
@@ -54,13 +63,22 @@ final class BrightnessWidget: StatusBarWidget, EventEmitting {
     private var popupPanel: PopupPanel?
     private var lastEmitted: [CGDirectDisplayID: Float] = [:]
 
+    // DDC slider coalescing: the slider's onChange fires per pixel, but we only
+    // want to push one write per ddcWriteDebounce. While a flush task is in
+    // flight, additional drags overwrite `pendingDDCWrites[id]` instead of
+    // queueing more I/O.
+    private var pendingDDCWrites: [CGDirectDisplayID: Float] = [:]
+    private var ddcFlushTask: Task<Void, Never>?
+
     private let service = BrightnessService.shared
 
     func start() {
         guard timer == nil, service.isAvailable, let interval = updateInterval else {
             return
         }
-        refreshDisplays()
+        Task { @MainActor in
+            await refreshDisplays()
+        }
         timer = Timer.publish(every: interval, tolerance: interval * 0.1, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
@@ -72,7 +90,7 @@ final class BrightnessWidget: StatusBarWidget, EventEmitting {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.refreshDisplays()
+                await self?.refreshDisplays()
             }
         }
     }
@@ -84,49 +102,32 @@ final class BrightnessWidget: StatusBarWidget, EventEmitting {
             NotificationCenter.default.removeObserver(observer)
             screenObserver = nil
         }
+        ddcFlushTask?.cancel()
+        ddcFlushTask = nil
+        pendingDDCWrites.removeAll()
         popupPanel?.hidePopup()
     }
 
     func body() -> some View {
-        Group {
-            if displays.isEmpty {
-                EmptyView()
-            } else {
-                HStack(spacing: 2) {
-                    Image(systemName: brightnessIconName(for: barBrightness))
-                        .font(Theme.sfIconFont)
-                        .foregroundStyle(.primary)
-                        .frame(width: 18, alignment: .center)
-                    Text("\(percent(barBrightness))%")
-                        .font(Theme.labelFont)
-                        .monospacedDigit()
-                        .foregroundStyle(.primary)
-                        .fixedSize()
-                        .frame(width: 38, alignment: .trailing)
-                        .contentTransition(.numericText())
-                }
-                .padding(.horizontal, 4)
-                .contentShape(Rectangle())
-                .onTapGesture { [weak self] in
-                    self?.togglePopup()
-                }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Brightness")
-                .accessibilityValue("\(percent(barBrightness))%")
-            }
+        BrightnessBarBody(displays: displays) { [weak self] in
+            self?.togglePopup()
         }
     }
 
     // MARK: - Polling
 
-    private func refreshDisplays() {
-        let fresh = service.enumerateDisplays()
+    private func refreshDisplays() async {
+        // Topology changed (or first scan) — drop any cached IOAVService handles
+        // before re-enumerating so we don't read from a stale I2C transport.
+        await service.invalidateExternalCache()
+        let fresh = await service.enumerateDisplays()
         let topologyChanged = Set(displays.map(\.id)) != Set(fresh.map(\.id))
         withAnimation(.numericTransition) {
             displays = fresh
         }
         if topologyChanged {
             lastEmitted = lastEmitted.filter { key, _ in fresh.contains { $0.id == key } }
+            pendingDDCWrites = pendingDDCWrites.filter { key, _ in fresh.contains { $0.id == key } }
             if popupPanel?.isVisible == true {
                 refreshPopup()
             }
@@ -134,26 +135,38 @@ final class BrightnessWidget: StatusBarWidget, EventEmitting {
     }
 
     private func poll() {
-        var changed = false
-        var updated = displays
-        for index in updated.indices {
-            guard let value = service.getBrightness(updated[index].id) else {
-                continue
+        let snapshot = displays.map { (id: $0.id, kind: $0.kind) }
+        Task { @MainActor in
+            var newValues: [CGDirectDisplayID: Float] = [:]
+            for entry in snapshot {
+                if let value = await service.getBrightness(entry.id, kind: entry.kind) {
+                    newValues[entry.id] = value
+                }
             }
-            if abs(updated[index].brightness - value) >= brightnessEpsilon {
-                updated[index].brightness = value
-                changed = true
+            guard !newValues.isEmpty else {
+                return
             }
-        }
-        guard changed else {
-            return
-        }
-        withAnimation(.numericTransition) {
-            displays = updated
-        }
-        emitChanges()
-        if popupPanel?.isVisible == true {
-            refreshPopup()
+            var updated = displays
+            var changed = false
+            for index in updated.indices {
+                guard let value = newValues[updated[index].id] else {
+                    continue
+                }
+                if abs(updated[index].brightness - value) >= brightnessEpsilon {
+                    updated[index].brightness = value
+                    changed = true
+                }
+            }
+            guard changed else {
+                return
+            }
+            withAnimation(.numericTransition) {
+                displays = updated
+            }
+            emitChanges()
+            if popupPanel?.isVisible == true {
+                refreshPopup()
+            }
         }
     }
 
@@ -174,27 +187,38 @@ final class BrightnessWidget: StatusBarWidget, EventEmitting {
     // MARK: - Slider write-through
 
     private func applyBrightness(_ value: Float, to displayID: CGDirectDisplayID) {
-        guard service.setBrightness(value, for: displayID) else {
+        guard let index = displays.firstIndex(where: { $0.id == displayID }) else {
             return
         }
-        if let index = displays.firstIndex(where: { $0.id == displayID }) {
-            displays[index].brightness = value
-        }
+        let kind = displays[index].kind
+        displays[index].brightness = value
         emitIfChanged(displayID: displayID, value: value)
-    }
 
-    // MARK: - Bar display
-
-    private var barBrightness: Float {
-        let mainID = CGMainDisplayID()
-        if let main = displays.first(where: { $0.id == mainID }) {
-            return main.brightness
+        switch kind {
+        case .builtin,
+             .displayServicesExternal:
+            Task { @MainActor in
+                _ = await service.setBrightness(value, for: displayID, kind: kind)
+            }
+        case .ddc:
+            pendingDDCWrites[displayID] = value
+            scheduleDDCFlush()
         }
-        return displays.first?.brightness ?? 0
     }
 
-    private func percent(_ value: Float) -> Int {
-        Int((value * 100).rounded())
+    private func scheduleDDCFlush() {
+        guard ddcFlushTask == nil else {
+            return
+        }
+        ddcFlushTask = Task { @MainActor in
+            try? await Task.sleep(for: ddcWriteDebounce)
+            let snapshot = pendingDDCWrites
+            pendingDDCWrites.removeAll()
+            ddcFlushTask = nil
+            for (id, value) in snapshot {
+                _ = await service.setBrightness(value, for: id, kind: .ddc)
+            }
+        }
     }
 
     // MARK: - Popup
@@ -232,6 +256,67 @@ final class BrightnessWidget: StatusBarWidget, EventEmitting {
                 self?.applyBrightness(value, to: displayID)
             }
         )
+    }
+}
+
+// MARK: - BrightnessBarBody
+
+/// Renders the bar entry for whichever display this bar instance lives on.
+/// `screenIndex` is injected by `BarContentView` for each per-screen bar window,
+/// so a multi-display setup ends up showing each display's own brightness in
+/// its own bar.
+private struct BrightnessBarBody: View {
+    let displays: [ManagedDisplay]
+    let onTap: () -> Void
+    @Environment(\.screenIndex) private var screenIndex
+
+    var body: some View {
+        Group {
+            if let display = currentDisplay {
+                HStack(spacing: 2) {
+                    Image(systemName: brightnessIconName(for: display.brightness))
+                        .font(Theme.sfIconFont)
+                        .foregroundStyle(.primary)
+                        .frame(width: 18, alignment: .center)
+                    Text("\(brightnessPercent(display.brightness))%")
+                        .font(Theme.labelFont)
+                        .monospacedDigit()
+                        .foregroundStyle(.primary)
+                        .fixedSize()
+                        .frame(width: 38, alignment: .trailing)
+                        .contentTransition(.numericText())
+                }
+                .padding(.horizontal, 4)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onTap)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(display.name)
+                .accessibilityValue("\(brightnessPercent(display.brightness))%")
+            } else {
+                EmptyView()
+            }
+        }
+    }
+
+    private var currentDisplay: ManagedDisplay? {
+        let screens = NSScreen.screens
+        guard screenIndex < screens.count else {
+            return nil
+        }
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        guard let id = screens[screenIndex].deviceDescription[key] as? CGDirectDisplayID else {
+            return nil
+        }
+        // Mirror secondary IDs aren't enumerated into `displays`; resolve to the
+        // primary so the bar still shows a value when the user mirrors.
+        var lookupID = id
+        if CGDisplayIsInMirrorSet(id) != 0 {
+            let primary = CGDisplayMirrorsDisplay(id)
+            if primary != 0 {
+                lookupID = primary
+            }
+        }
+        return displays.first(where: { $0.id == lookupID })
     }
 }
 

--- a/Sources/StatusBar/Widgets/BrightnessWidget.swift
+++ b/Sources/StatusBar/Widgets/BrightnessWidget.swift
@@ -271,30 +271,26 @@ private struct BrightnessBarBody: View {
     @Environment(\.screenIndex) private var screenIndex
 
     var body: some View {
-        Group {
-            if let display = currentDisplay {
-                HStack(spacing: 2) {
-                    Image(systemName: brightnessIconName(for: display.brightness))
-                        .font(Theme.sfIconFont)
-                        .foregroundStyle(.primary)
-                        .frame(width: 18, alignment: .center)
-                    Text("\(brightnessPercent(display.brightness))%")
-                        .font(Theme.labelFont)
-                        .monospacedDigit()
-                        .foregroundStyle(.primary)
-                        .fixedSize()
-                        .frame(width: 38, alignment: .trailing)
-                        .contentTransition(.numericText())
-                }
-                .padding(.horizontal, 4)
-                .contentShape(Rectangle())
-                .onTapGesture(perform: onTap)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(display.name)
-                .accessibilityValue("\(brightnessPercent(display.brightness))%")
-            } else {
-                EmptyView()
+        if let display = currentDisplay {
+            HStack(spacing: 2) {
+                Image(systemName: brightnessIconName(for: display.brightness))
+                    .font(Theme.sfIconFont)
+                    .foregroundStyle(.primary)
+                    .frame(width: 18, alignment: .center)
+                Text("\(brightnessPercent(display.brightness))%")
+                    .font(Theme.labelFont)
+                    .monospacedDigit()
+                    .foregroundStyle(.primary)
+                    .fixedSize()
+                    .frame(width: 38, alignment: .trailing)
+                    .contentTransition(.numericText())
             }
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
+            .onTapGesture(perform: onTap)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(display.name)
+            .accessibilityValue("\(brightnessPercent(display.brightness))%")
         }
     }
 


### PR DESCRIPTION
## Summary

Adds external display brightness control to the brightness widget. The bar now shows the brightness of the display each bar instance is rendered on, instead of always pulling from `CGMainDisplayID()`.

The strategy is **DisplayServices first, DDC/CI as fallback**: every online display is tried through the existing `DisplayServices` SPI; only displays that don't respond fall through to a new `DDCService` that talks DDC/CI over the `CoreDisplay` `IOAVService` SPI. In practice this covers built-in panels, Apple-branded externals, and most third-party HDR monitors whose brightness the System Settings slider already controls. Monitors that only speak DDC/CI (no DisplayServices route) get picked up by the fallback.

## Changes

- **`Sources/StatusBar/Services/DDCService.swift`** (new) — actor implementing DDC/CI. Loads `IOAVServiceCreateWithService`, `IOAVServiceReadI2C`, `IOAVServiceWriteI2C`, `CoreDisplay_DisplayCreateInfoDictionary` via `dlopen` (covered by existing `disable-library-validation`). Walks IOService for `AppleCLCD2` / `IOMobileFramebufferShim` + `DCPAVServiceProxy(Location=External)` pairs, matches to `CGDirectDisplayID` via EDID UUID scoring (port of MonitorControl's `Arm64DDC`). Reads/writes VCP `0x10` with checksum and retry, normalizes per-display VCP max to `0...1`, and skips polling reads for ~250 ms after a write to dodge stale I2C reads.
- **`Sources/StatusBar/Services/BrightnessService.swift`** — adds `DisplayKind` (`.builtin` / `.displayServicesExternal` / `.ddc`). `enumerateDisplays` / `getBrightness` / `setBrightness` are now `async` and dispatch by kind. `invalidateExternalCache()` lets the widget drop stale `IOAVService` handles on topology changes.
- **`Sources/StatusBar/Widgets/BrightnessWidget.swift`**
  - Migrated to async I/O for polling and slider write-through.
  - DDC slider writes are coalesced on a 40 ms window so a fast drag doesn't overrun the I2C bus.
  - `didChangeScreenParametersNotification` invalidates the DDC cache before re-enumerating.
  - New `BrightnessBarBody` reads `@Environment(\.screenIndex)` from `BarContentView` and resolves the bar's own `CGDirectDisplayID` via `NSScreen.deviceDescription`, so each per-screen bar window shows only its own display's brightness. Mirror secondary IDs fall back to the primary.

## Notes

- Apple Silicon only. The DDC fallback uses the `IOAVService` path which has no Intel equivalent. macOS 26 already constrains the project to Apple Silicon hardware, so this is not a regression.
- `disable-library-validation` already covers `CoreDisplay`'s unexported SPI alongside `DisplayServices`, so no entitlement change is needed.
- The popup keeps the previous behavior of listing every controllable display with its own slider. Only the bar entry was scoped down to the local screen.
- Displays whose brightness can't be read by either path are dropped from the list rather than shown with a stub value.