### PR TITLE
feat: add GitHub repository link to About page

### DIFF
--- a/Sources/StatusBar/Preferences/Sections/AboutSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/AboutSection.swift
@@ -78,6 +78,17 @@ struct AboutSection: View {
                         }
                         .controlSize(.small)
                     }
+                    HStack {
+                        Text("GitHub Repository")
+                            .frame(width: 120, alignment: .leading)
+                        Spacer()
+                        Button("Open on GitHub") {
+                            if let url = URL(string: "https://github.com/hytfjwr/StatusBar") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }
+                        .controlSize(.small)
+                    }
                 }
                 .padding(8)
             }


### PR DESCRIPTION
Adds an "Open on GitHub" button to the Help section of the About page in Preferences, linking to https://github.com/hytfjwr/StatusBar. Follows the existing row layout used by Welcome Guide and Changelog.