### PR TITLE
feat: add button to open config.yml in General preferences

### DIFF
--- a/Sources/StatusBar/Config/ConfigLoader.swift
+++ b/Sources/StatusBar/Config/ConfigLoader.swift
@@ -26,6 +26,12 @@ final class ConfigLoader {
     private(set) var currentConfig = StatusBarConfig()
 
     private let fileURL: URL
+
+    /// Public accessor for `~/.config/statusbar/config.yml`.
+    var configFileURL: URL {
+        fileURL
+    }
+
     private var fsSource: DispatchSourceFileSystemObject?
     private var writeTask: Task<Void, Never>?
 

--- a/Sources/StatusBar/Preferences/Sections/GeneralSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/GeneralSection.swift
@@ -1,3 +1,4 @@
+import AppKit
 import StatusBarKit
 import SwiftUI
 
@@ -22,6 +23,21 @@ struct GeneralSection: View {
                 VStack(spacing: 10) {
                     SliderRow(label: "Widget Spacing", value: $model.widgetSpacing, range: 0 ... 16)
                     SliderRow(label: "Padding H", value: $model.widgetPaddingH, range: 0 ... 16)
+                }
+                .padding(8)
+            }
+
+            GroupBox("Config File") {
+                HStack {
+                    Text(ConfigLoader.shared.configFileURL.path)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer()
+                    Button("Open config.yml") {
+                        NSWorkspace.shared.open(ConfigLoader.shared.configFileURL)
+                    }
                 }
                 .padding(8)
             }


### PR DESCRIPTION
## Summary
Adds a "Config File" group to the General preferences section, showing the full path to `config.yml` and an **Open config.yml** button that opens the file in the user's default editor via `NSWorkspace`.

## Changes
- Expose `ConfigLoader.configFileURL` as a public accessor so the preferences UI doesn't duplicate the path logic.
- Add a `GroupBox("Config File")` row in `GeneralSection` with the path label and an open button.

## Notes
- The button assumes the file exists (it is created on first launch by `ConfigLoader.bootstrap()`), so no disabled/missing-file handling is added.
- Opens in whichever app is associated with `.yml` — typically TextEdit.