### PR TITLE
feat: add sbar plugins install / uninstall

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6d04fc12440ea20e3f8122b1c43618d8858c918c6ccb0d608833a6526f010591",
+  "originHash" : "ec54e59d5babb07f5f13ec36e991f9196247b3985a69664fcf623f0e3b7ccc77",
   "pins" : [
     {
       "identity" : "statusbarkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hytfjwr/StatusBarKit",
       "state" : {
-        "revision" : "5b5426f7b240975ec644d8c40be4f001d33fb277",
-        "version" : "1.9.0"
+        "revision" : "390a401fa8e52c8b9c575993eb41cd49bd54b55b",
+        "version" : "1.10.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     name: "StatusBar",
     platforms: [.macOS(.v26)],
     dependencies: [
-        .package(url: "https://github.com/hytfjwr/StatusBarKit", from: "1.9.0"),
+        .package(url: "https://github.com/hytfjwr/StatusBarKit", from: "1.10.0"),
         .package(url: "https://github.com/jpsim/Yams", from: "6.2.1"),
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.58.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),

--- a/README.md
+++ b/README.md
@@ -71,9 +71,20 @@ Plugin state lives in two YAML files alongside `config.yml`:
 - **`~/.config/statusbar/plugins.yml`** — declarative manifest. Each entry is `source: github:owner/repo` plus `version: "1.2.0"` (exact) or `version: latest`. Safe to commit alongside your dotfiles.
 - **`~/.config/statusbar/plugins-lock.yml`** — resolved snapshot. Auto-generated and updated by sync; records the exact tag, asset URL, and zip SHA-256 needed to reinstall the same versions on another machine.
 
-GUI install/uninstall, manual edits, and `sbar plugins sync` all update the same files. A "Sync Plugins" button in Preferences (and `sbar plugins sync`) reconciles the manifest with what's installed: missing plugins are downloaded, declared updates applied, and plugins removed from `plugins.yml` are auto-uninstalled.
+GUI install/uninstall, manual edits, `sbar plugins install/uninstall`, and `sbar plugins sync` all update the same files. A "Sync Plugins" button in Preferences (and `sbar plugins sync`) reconciles the manifest with what's installed: missing plugins are downloaded, declared updates applied, and plugins removed from `plugins.yml` are auto-uninstalled.
 
 Run `sbar plugins sync --frozen` to install strictly from the lockfile without contacting GitHub — useful for CI or restoring a known-good environment.
+
+From the CLI:
+
+```bash
+sbar plugins install hytfjwr/statusbar-plugin-spotify       # latest release
+sbar plugins install hytfjwr/statusbar-plugin-spotify --version 0.3.0
+sbar plugins install https://github.com/hytfjwr/statusbar-plugin-spotify  # clone URLs work too
+sbar plugins uninstall hytfjwr/statusbar-plugin-spotify
+```
+
+Install resolves `--version` against GitHub releases (omit it to pick `latest`, or to preserve a pin already in `plugins.yml`), downloads the `.statusplugin.zip` asset, updates the manifest + lockfile, and hot-loads the dylib so the widget appears without restart. Uninstall reverses all of that.
 
 ### Official Plugins
 
@@ -293,11 +304,15 @@ sbar toast --title "Deploy done" --message "v1.2.3 shipped" --level success
 sbar toast --title "CPU Warning" --level warning --duration 10
 sbar toast --title "Error" --level error --action-label "Open Logs" --action "open /var/log"
 
-# Plugin manifest sync (reads ~/.config/statusbar/plugins.yml)
+# Plugin manifest (reads/writes ~/.config/statusbar/plugins.yml)
 sbar plugins list
 sbar plugins list --json
 sbar plugins sync
-sbar plugins sync --frozen   # install strictly from plugins-lock.yml, no network resolution
+sbar plugins sync --frozen                # install strictly from plugins-lock.yml, no network resolution
+sbar plugins install owner/repo           # accepts owner/repo, github:owner/repo, or https URL
+sbar plugins install owner/repo --version 1.2.0
+sbar plugins install owner/repo --json    # emit InstalledPluginDTO for scripts
+sbar plugins uninstall owner/repo
 
 # Relaunch the app
 sbar reload

--- a/Sources/StatusBar/IPC/CommandDispatcher.swift
+++ b/Sources/StatusBar/IPC/CommandDispatcher.swift
@@ -22,12 +22,14 @@ final class CommandDispatcher {
             ToastCommandHandler(),
             PluginsSyncCommandHandler(),
             PluginsListCommandHandler(),
+            PluginsInstallCommandHandler(),
+            PluginsUninstallCommandHandler(),
         ]
         handlers = Dictionary(uniqueKeysWithValues: all.map { ($0.commandKey, $0) })
     }
 
     /// Process an IPC request and return the response.
-    func dispatch(_ request: IPCRequest) -> IPCResponse {
+    func dispatch(_ request: IPCRequest) async -> IPCResponse {
         if request.version != ipcProtocolVersion {
             return IPCResponse(
                 requestID: request.requestID,
@@ -42,7 +44,7 @@ final class CommandDispatcher {
         let handlerKey = request.command.handlerKey
         if let handler = handlers[handlerKey] {
             do {
-                let payload = try handler.handle(request.command)
+                let payload = try await handler.handle(request.command)
                 result = .success(payload)
             } catch let error as IPCError {
                 result = .failure(error)
@@ -74,6 +76,8 @@ extension IPCCommand {
         case .showToast: "showToast"
         case .pluginsSync: "pluginsSync"
         case .pluginsList: "pluginsList"
+        case .pluginsInstall: "pluginsInstall"
+        case .pluginsUninstall: "pluginsUninstall"
         @unknown default: "unknown"
         }
     }

--- a/Sources/StatusBar/IPC/CommandHandling.swift
+++ b/Sources/StatusBar/IPC/CommandHandling.swift
@@ -5,5 +5,5 @@ import StatusBarKit
 @MainActor
 protocol CommandHandling {
     var commandKey: String { get }
-    func handle(_ command: IPCCommand) throws -> IPCPayload
+    func handle(_ command: IPCCommand) async throws -> IPCPayload
 }

--- a/Sources/StatusBar/IPC/Handlers/GetWidgetCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/GetWidgetCommandHandler.swift
@@ -7,7 +7,7 @@ import StatusBarKit
 struct GetWidgetCommandHandler: CommandHandling {
     let commandKey = "getWidget"
 
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         guard case let .getWidget(id) = command else {
             throw IPCError.unknownCommand
         }

--- a/Sources/StatusBar/IPC/Handlers/ListCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/ListCommandHandler.swift
@@ -4,7 +4,7 @@ import StatusBarKit
 struct ListCommandHandler: CommandHandling {
     let commandKey = "list"
 
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         let allSettings = WidgetConfigRegistry.shared.exportAll()
         let dtos = WidgetRegistry.shared.layout.map { entry in
             WidgetInfoDTO.make(from: entry, settings: allSettings[entry.id] ?? [:])

--- a/Sources/StatusBar/IPC/Handlers/PluginsInstallCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/PluginsInstallCommandHandler.swift
@@ -1,0 +1,104 @@
+import Foundation
+import OSLog
+import StatusBarKit
+
+private let logger = Logger(subsystem: "com.statusbar", category: "PluginsInstallCommandHandler")
+
+// MARK: - PluginsInstallCommandHandler
+
+@MainActor
+struct PluginsInstallCommandHandler: CommandHandling {
+    let commandKey = "pluginsInstall"
+
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
+        guard case let .pluginsInstall(source, version) = command else {
+            throw IPCError.unknownCommand
+        }
+        // When the CLI omits --version, preserve any pre-existing pin in plugins.yml.
+        // Otherwise `add()` would overwrite `version: 1.2.0` with `version: latest`,
+        // silently undoing the user's pin on a routine reinstall.
+        let manager = PluginsManager.shared
+        let resolvedVersion: String = if let version {
+            version
+        } else if let existing = manager.manifestStore.currentManifest.plugins.first(
+            where: { $0.source.lowercased() == source.lowercased() }
+        ) {
+            existing.version
+        } else {
+            "latest"
+        }
+
+        let result: PluginsManager.AddResult
+        do {
+            result = try await manager.add(source: source, version: resolvedVersion)
+        } catch {
+            throw IPCError.internalError(error.localizedDescription)
+        }
+        let record = result.record
+
+        // Only hot-load when something on disk actually changed. Calling `reload()` on an
+        // already-loaded plugin at the same version tears down its widgets and rebuilds them
+        // from disk, throwing away graph buffers, popup state, and other in-memory state —
+        // surprising behavior for an idempotent `sbar plugins install` re-run.
+        if result.action != .skipped {
+            _ = hotLoad(record: record)
+        }
+
+        return .pluginInstalled(InstalledPluginDTO(
+            id: record.id,
+            name: record.name,
+            version: record.version,
+            bundleName: record.bundleName,
+            source: source,
+            installedAt: record.installedAt
+        ))
+    }
+
+    /// Hot-load (or hot-reload, when the plugin was already loaded at a previous version) and
+    /// start any newly added widgets. Returns true when the widgets are usable without restart.
+    private func hotLoad(record: InstalledPluginRecord) -> Bool {
+        let loader = DylibPluginLoader.shared
+        let registry = WidgetRegistry.shared
+        let bundleURL = Self.bundleURL(for: record)
+
+        if loader.isLoaded(record.id) {
+            do {
+                _ = try loader.reload(pluginID: record.id, bundleURL: bundleURL, into: registry)
+                registry.finalizeRegistration()
+                startWidgets(for: record.id, in: registry, loader: loader)
+                return true
+            } catch {
+                logger.warning("Hot-reload failed for \(record.id): \(error.localizedDescription)")
+                return false
+            }
+        }
+
+        let existingIDs = Set(registry.layout.map(\.id))
+        do {
+            _ = try loader.load(bundleURL: bundleURL, into: registry)
+            registry.finalizeRegistration()
+            let widgets = registry.leftWidgets + registry.centerWidgets + registry.rightWidgets
+            for widget in widgets where !existingIDs.contains(widget.id) {
+                widget.start()
+            }
+            return true
+        } catch {
+            logger.warning("Hot-load failed for \(record.id): \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private func startWidgets(for pluginID: String, in registry: WidgetRegistry, loader: DylibPluginLoader) {
+        let widgets = registry.leftWidgets + registry.centerWidgets + registry.rightWidgets
+        let pluginWidgetIDs = Set(loader.widgetIDs(for: pluginID))
+        for widget in widgets where pluginWidgetIDs.contains(widget.id) {
+            widget.start()
+        }
+    }
+
+    static func bundleURL(for record: InstalledPluginRecord) -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/statusbar/plugins")
+            .appendingPathComponent("\(record.bundleName).statusplugin")
+    }
+}

--- a/Sources/StatusBar/IPC/Handlers/PluginsListCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/PluginsListCommandHandler.swift
@@ -4,7 +4,7 @@ import StatusBarKit
 struct PluginsListCommandHandler: CommandHandling {
     let commandKey = "pluginsList"
 
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         guard case .pluginsList = command else {
             throw IPCError.unknownCommand
         }

--- a/Sources/StatusBar/IPC/Handlers/PluginsSyncCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/PluginsSyncCommandHandler.swift
@@ -4,7 +4,7 @@ import StatusBarKit
 struct PluginsSyncCommandHandler: CommandHandling {
     let commandKey = "pluginsSync"
 
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         guard case let .pluginsSync(frozen) = command else {
             throw IPCError.unknownCommand
         }

--- a/Sources/StatusBar/IPC/Handlers/PluginsUninstallCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/PluginsUninstallCommandHandler.swift
@@ -1,0 +1,18 @@
+import StatusBarKit
+
+@MainActor
+struct PluginsUninstallCommandHandler: CommandHandling {
+    let commandKey = "pluginsUninstall"
+
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
+        guard case let .pluginsUninstall(source) = command else {
+            throw IPCError.unknownCommand
+        }
+        do {
+            try await PluginsManager.shared.remove(source: source)
+        } catch {
+            throw IPCError.internalError(error.localizedDescription)
+        }
+        return .ok
+    }
+}

--- a/Sources/StatusBar/IPC/Handlers/ReloadCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/ReloadCommandHandler.swift
@@ -4,7 +4,7 @@ import StatusBarKit
 struct ReloadCommandHandler: CommandHandling {
     let commandKey = "reload"
 
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         AppUpdateService.relaunchApp()
         return .ok
     }

--- a/Sources/StatusBar/IPC/Handlers/SetGlobalCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/SetGlobalCommandHandler.swift
@@ -6,7 +6,7 @@ struct SetGlobalCommandHandler: CommandHandling {
     let commandKey = "setGlobal"
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         guard case let .setGlobal(keyPath, value) = command else {
             throw IPCError.unknownCommand
         }

--- a/Sources/StatusBar/IPC/Handlers/SetWidgetCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/SetWidgetCommandHandler.swift
@@ -4,7 +4,7 @@ import StatusBarKit
 struct SetWidgetCommandHandler: CommandHandling {
     let commandKey = "setWidget"
 
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         guard case let .setWidget(id, key, value) = command else {
             throw IPCError.unknownCommand
         }

--- a/Sources/StatusBar/IPC/Handlers/ToastCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/ToastCommandHandler.swift
@@ -4,7 +4,7 @@ import StatusBarKit
 struct ToastCommandHandler: CommandHandling {
     let commandKey = "showToast"
 
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         guard case let .showToast(request) = command else {
             throw IPCError.unknownCommand
         }

--- a/Sources/StatusBar/IPC/Handlers/TriggerCommandHandler.swift
+++ b/Sources/StatusBar/IPC/Handlers/TriggerCommandHandler.swift
@@ -5,7 +5,7 @@ import StatusBarKit
 struct TriggerCommandHandler: CommandHandling {
     let commandKey = "trigger"
 
-    func handle(_ command: IPCCommand) throws -> IPCPayload {
+    func handle(_ command: IPCCommand) async throws -> IPCPayload {
         guard case let .trigger(eventName, payload) = command else {
             throw IPCError.unknownCommand
         }

--- a/Sources/StatusBar/IPC/IPCServer.swift
+++ b/Sources/StatusBar/IPC/IPCServer.swift
@@ -66,9 +66,13 @@ private func handleClient(fd: Int32, dispatcher: CommandDispatcher) {
         // Standard request-response path.
         defer { close(fd) }
 
-        let response = await MainActor.run {
-            dispatcher.dispatch(request)
-        }
+        // Now that the request is fully read, clear the 5s send timeout so a long-running
+        // handler (e.g. pluginsInstall downloading a GitHub release) doesn't accidentally
+        // expire SO_SNDTIMEO on the response write if the kernel send buffer is under pressure.
+        var noTimeout = timeval(tv_sec: 0, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &noTimeout, socklen_t(MemoryLayout<timeval>.size))
+
+        let response = await dispatcher.dispatch(request)
 
         do {
             let frame = try IPCFraming.encode(response)

--- a/Sources/StatusBar/Plugins/PluginsManager.swift
+++ b/Sources/StatusBar/Plugins/PluginsManager.swift
@@ -52,6 +52,11 @@ final class PluginsManager {
     /// In-flight sync task — used to coalesce concurrent sync() callers.
     private var inFlightSync: Task<PluginsSyncResult, any Error>?
 
+    /// Tail of the serialized mutation chain (add / remove). New mutators await this so
+    /// concurrent CLI installs / uninstalls cannot interleave their manifest+lock writes.
+    /// `Result<Void, Never>` so a failed predecessor never propagates and blocks the queue.
+    private var mutationTail: Task<Void, Never>?
+
     private init() {
         manifestStore = .shared
         pluginStore = .shared
@@ -150,15 +155,20 @@ final class PluginsManager {
     /// Concurrent callers share a single in-flight sync to avoid duplicate downloads.
     /// - Parameter frozen: When true, resolves only from `plugins-lock.yml` and never contacts GitHub.
     func sync(frozen: Bool = false) async throws -> PluginsSyncResult {
+        // Coalesce concurrent sync callers (they want the same result, no point doing the work
+        // twice). Also queue behind any in-flight add/remove via the shared mutation chain so
+        // a sync mid-install doesn't clobber the lockfile from a stale snapshot.
         if let existing = inFlightSync {
             return try await existing.value
         }
-        let task = Task { @MainActor [weak self] () throws -> PluginsSyncResult in
+        let task = Task<PluginsSyncResult, any Error> { @MainActor [weak self] () throws -> PluginsSyncResult in
             guard let self else {
                 return PluginsSyncResult()
             }
             defer { self.inFlightSync = nil }
-            return try await self.runSync(frozen: frozen)
+            return try await self.serializeMutation { [self] in
+                try await runSync(frozen: frozen)
+            }
         }
         inFlightSync = task
         return try await task.value
@@ -219,11 +229,26 @@ final class PluginsManager {
 
     // MARK: - GUI helpers
 
+    /// Outcome of `add(source:version:)`. `action` lets callers skip a hot-reload when nothing
+    /// on disk changed — without it, repeating `sbar plugins install foo` would tear down + rebuild
+    /// the live widgets at the same version, losing per-widget runtime state.
+    struct AddResult {
+        enum Action { case installed, updated, skipped }
+        let record: InstalledPluginRecord
+        let action: Action
+    }
+
     /// Append (or update) an entry in plugins.yml and immediately install the plugin.
     /// Installs first and only persists the manifest if the install succeeds, so a failed
     /// network request never leaves a poisoned entry in plugins.yml.
     @discardableResult
-    func add(source: String, version: String) async throws -> InstalledPluginRecord {
+    func add(source: String, version: String) async throws -> AddResult {
+        try await serializeMutation { [self] in
+            try await unsafeAdd(source: source, version: version)
+        }
+    }
+
+    private func unsafeAdd(source: String, version: String) async throws -> AddResult {
         let entry = PluginsManifestEntry(source: source, version: version)
         guard entry.parseGitHubSource() != nil else {
             throw PluginsManifestError.invalidSource(source)
@@ -232,9 +257,14 @@ final class PluginsManager {
         // Install first so a failure does not pollute plugins.yml.
         let outcome = try await applyEntry(entry, lock: manifestStore.currentLock, frozen: false)
 
+        // GitHub repo names are case-insensitive — match the existing manifest/lock entry
+        // case-insensitively so re-installing with a different casing updates rather than
+        // duplicating, matching the drift-comparison convention used in runSync().
+        let target = source.lowercased()
+
         // Persist manifest (update existing entry if present, otherwise append).
         var manifest = manifestStore.currentManifest
-        if let index = manifest.plugins.firstIndex(where: { $0.source == source }) {
+        if let index = manifest.plugins.firstIndex(where: { $0.source.lowercased() == target }) {
             manifest.plugins[index] = entry
         } else {
             manifest.plugins.append(entry)
@@ -243,19 +273,67 @@ final class PluginsManager {
 
         // Persist lock.
         var updatedLock = manifestStore.currentLock
-        if let index = updatedLock.plugins.firstIndex(where: { $0.source == source }) {
+        if let index = updatedLock.plugins.firstIndex(where: { $0.source.lowercased() == target }) {
             updatedLock.plugins[index] = outcome.lockEntry
         } else {
             updatedLock.plugins.append(outcome.lockEntry)
         }
         try manifestStore.saveLock(updatedLock)
-        return outcome.record
+        let action: AddResult.Action = switch outcome.action {
+        case .installed: .installed
+        case .updated: .updated
+        case .skipped: .skipped
+        }
+        return AddResult(record: outcome.record, action: action)
+    }
+
+    /// Remove a plugin by its plugins.yml source ("github:owner/repo"). Resolves to a pluginID
+    /// via the lockfile (preferred) or the installed registry, then delegates to `remove(pluginID:)`.
+    /// Matching is case-insensitive because GitHub repository names are case-insensitive — this
+    /// mirrors the drift-detection logic in `runSync()`.
+    /// When neither pluginStore nor any other ground-truth source has a record but the lockfile
+    /// does (e.g., the plugin failed to load at boot), the manifest+lock entries are removed
+    /// directly so the user can recover via CLI without hand-editing plugins.yml.
+    /// `async` so it can wait for an in-flight `add()` to finish before mutating the manifest.
+    func remove(source: String) async throws {
+        try await serializeMutation { [self] in
+            try unsafeRemove(source: source)
+        }
+    }
+
+    private func unsafeRemove(source: String) throws {
+        let target = source.lowercased()
+        if let record = pluginStore.plugins.first(where: {
+            PluginsManifestEntry.source(fromGitHubURL: $0.githubURL)?.lowercased() == target
+        }) {
+            try unsafeRemove(pluginID: record.id)
+            return
+        }
+        if manifestStore.currentLock.plugins.contains(where: { $0.source.lowercased() == target }) {
+            // Orphan lock entry (no matching registry record). Clear manifest+lock without
+            // calling installer.uninstall — there's nothing on disk to remove.
+            var manifest = manifestStore.currentManifest
+            manifest.plugins.removeAll { $0.source.lowercased() == target }
+            try manifestStore.saveManifest(manifest)
+            var lock = manifestStore.currentLock
+            lock.plugins.removeAll { $0.source.lowercased() == target }
+            try manifestStore.saveLock(lock)
+            return
+        }
+        throw PluginsManagerError.unknownSource(source)
     }
 
     /// Remove a plugin: delete the bundle from disk, then drop the entry from manifest + lock + registry.
     /// Bundle removal runs first so a permission error leaves the runtime state recoverable.
     /// Local plugins (`isLocal == true`) cannot be removed via this path — they are not managed by plugins.yml.
-    func remove(pluginID: String) throws {
+    /// `async` so it can wait for an in-flight `add()` to finish before mutating the manifest.
+    func remove(pluginID: String) async throws {
+        try await serializeMutation { [self] in
+            try unsafeRemove(pluginID: pluginID)
+        }
+    }
+
+    private func unsafeRemove(pluginID: String) throws {
         guard let record = pluginStore.record(forID: pluginID) else {
             throw PluginsManagerError.unknownPlugin(pluginID)
         }
@@ -271,13 +349,38 @@ final class PluginsManager {
         // Only then tear down the live widgets and update the manifest/lock files.
         DylibPluginLoader.shared.markForRemoval(pluginID: pluginID, from: WidgetRegistry.shared)
 
+        // Case-insensitive match: plugins.yml may have been hand-edited with a different
+        // casing than the registry's githubURL. Without this, the bundle is gone but the
+        // manifest entry survives, and next sync re-installs the plugin.
+        let target = source.lowercased()
         var manifest = manifestStore.currentManifest
-        manifest.plugins.removeAll { $0.source == source }
+        manifest.plugins.removeAll { $0.source.lowercased() == target }
         try manifestStore.saveManifest(manifest)
 
         var lock = manifestStore.currentLock
-        lock.plugins.removeAll { $0.source == source }
+        lock.plugins.removeAll { $0.source.lowercased() == target }
         try manifestStore.saveLock(lock)
+    }
+
+    // MARK: - Mutation serialization
+
+    /// Run `work` after any prior add/remove/sync finishes. Prevents races where one mutator
+    /// yields on a GitHub download while a sibling mutator writes the manifest/lock from a stale
+    /// snapshot. The await chain is placed *inside* the new task body — not in the caller — so
+    /// two callers queued behind the same predecessor still serialize against each other when
+    /// the predecessor completes.
+    private func serializeMutation<T: Sendable>(
+        _ work: @MainActor @escaping () async throws -> T
+    ) async throws -> T {
+        let previous = mutationTail
+        let task = Task<T, any Error> { @MainActor in
+            _ = await previous?.value
+            return try await work()
+        }
+        // The tail erases the result type and ignores errors so a failed predecessor
+        // never blocks the queue.
+        mutationTail = Task<Void, Never> { _ = try? await task.value }
+        return try await task.value
     }
 
     // MARK: - Manifest DTOs (for IPC)
@@ -430,6 +533,7 @@ final class PluginsManager {
 
 enum PluginsManagerError: Error, LocalizedError {
     case unknownPlugin(String)
+    case unknownSource(String)
     case localPluginNotManaged(String)
     case frozenMissingLockEntry(String)
     case frozenIncompleteLockEntry(String)
@@ -438,6 +542,8 @@ enum PluginsManagerError: Error, LocalizedError {
         switch self {
         case let .unknownPlugin(id):
             "Unknown plugin: \(id)"
+        case let .unknownSource(source):
+            "No installed plugin matches source \(source)"
         case let .localPluginNotManaged(id):
             "Local plugin \(id) is not managed by plugins.yml"
         case let .frozenMissingLockEntry(source):

--- a/Sources/StatusBar/Preferences/Sections/PluginsSection.swift
+++ b/Sources/StatusBar/Preferences/Sections/PluginsSection.swift
@@ -344,7 +344,7 @@ extension PluginsSection {
                 guard let source = PluginsManifestEntry.source(fromGitHubURL: update.githubURL) else {
                     throw PluginsManagerError.unknownPlugin(update.pluginID)
                 }
-                let record = try await manager.add(source: source, version: "latest")
+                let record = try await manager.add(source: source, version: "latest").record
                 availableUpdates.removeAll { $0.pluginID == update.pluginID }
 
                 // Attempt hot-reload if the old plugin is loaded, otherwise cold-load
@@ -390,7 +390,7 @@ extension PluginsSection {
             do {
                 let (owner, repo) = try GitHubPluginInstaller.shared.parseGitHubURL(githubURL)
                 let source = "github:\(owner)/\(repo)"
-                let record = try await manager.add(source: source, version: "latest")
+                let record = try await manager.add(source: source, version: "latest").record
                 githubURL = ""
 
                 // Try hot-loading the plugin immediately
@@ -537,11 +537,13 @@ extension PluginsSection {
     }
 
     private func uninstallPlugin(id: String) {
-        do {
-            try manager.remove(pluginID: id)
-            needsRestart = true
-        } catch {
-            installError = "Failed to uninstall: \(error.localizedDescription)"
+        Task {
+            do {
+                try await manager.remove(pluginID: id)
+                needsRestart = true
+            } catch {
+                installError = "Failed to uninstall: \(error.localizedDescription)"
+            }
         }
     }
 

--- a/Sources/statusbar-cli/Commands/PluginsCommand.swift
+++ b/Sources/statusbar-cli/Commands/PluginsCommand.swift
@@ -8,7 +8,12 @@ struct PluginsCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "plugins",
         abstract: "Manage plugins.yml / plugins-lock.yml",
-        subcommands: [PluginsSyncCommand.self, PluginsListCommand.self]
+        subcommands: [
+            PluginsSyncCommand.self,
+            PluginsListCommand.self,
+            PluginsInstallCommand.self,
+            PluginsUninstallCommand.self,
+        ]
     )
 }
 
@@ -71,5 +76,165 @@ struct PluginsListCommand: ParsableCommand {
             return "[]"
         }
         return json
+    }
+}
+
+// MARK: - PluginsInstallCommand
+
+struct PluginsInstallCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "install",
+        abstract: "Install a plugin from GitHub, updating plugins.yml + plugins-lock.yml"
+    )
+
+    @Argument(help: ArgumentHelp(
+        "Plugin source — accepts owner/repo, github:owner/repo, or https://github.com/owner/repo",
+        valueName: "source"
+    ))
+    var source: String
+
+    @Option(name: .long, help: "Release tag to install (defaults to the latest GitHub release)")
+    var version: String?
+
+    @OptionGroup var options: GlobalOptions
+
+    func run() throws {
+        let normalizedSource: String
+        do {
+            normalizedSource = try PluginSourceParser.normalize(source)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+
+        let payload = try IPCClient.send(.pluginsInstall(source: normalizedSource, version: version))
+        guard case let .pluginInstalled(installed) = payload else {
+            throw ExitCode.failure
+        }
+
+        if options.json {
+            print(jsonOutput(installed))
+            return
+        }
+        print("Installed \(installed.name) v\(installed.version) (\(installed.source))")
+    }
+
+    private func jsonOutput(_ dto: InstalledPluginDTO) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(dto),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return json
+    }
+}
+
+// MARK: - PluginsUninstallCommand
+
+struct PluginsUninstallCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "uninstall",
+        abstract: "Remove a plugin from plugins.yml + plugins-lock.yml and delete its bundle"
+    )
+
+    @Argument(help: ArgumentHelp(
+        "Plugin source — accepts owner/repo, github:owner/repo, or https://github.com/owner/repo",
+        valueName: "source"
+    ))
+    var source: String
+
+    func run() throws {
+        let normalizedSource: String
+        do {
+            normalizedSource = try PluginSourceParser.normalize(source)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+
+        let payload = try IPCClient.send(.pluginsUninstall(source: normalizedSource))
+        guard case .ok = payload else {
+            throw ExitCode.failure
+        }
+        print("Uninstalled \(normalizedSource)")
+    }
+}
+
+// MARK: - PluginSourceParser
+
+/// Normalizes the three accepted source forms (owner/repo, github:owner/repo,
+/// https://github.com/owner/repo) into the canonical `github:owner/repo` string
+/// stored in plugins.yml.
+enum PluginSourceParser {
+    enum ParseError: Error, LocalizedError {
+        case empty
+        case invalidFormat(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .empty:
+                "source must not be empty"
+            case let .invalidFormat(input):
+                "invalid source '\(input)' — expected owner/repo, github:owner/repo, or https://github.com/owner/repo"
+            }
+        }
+    }
+
+    static func normalize(_ input: String) throws -> String {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ParseError.empty
+        }
+
+        let stripped: String = if trimmed.hasPrefix("github:") {
+            String(trimmed.dropFirst("github:".count))
+        } else if let owner = stripGitHubURL(trimmed) {
+            owner
+        } else {
+            trimmed
+        }
+
+        let parts = stripped.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              validateSegment(parts[0])
+        else {
+            throw ParseError.invalidFormat(input)
+        }
+        // Strip a trailing ".git" from the repo segment so pasted clone URLs (e.g.
+        // `git@`/`https` clone form ending in `.git`) canonicalize to the same source string
+        // that GitHubPluginInstaller.parseGitHubURL stores on the registry record. Without
+        // this, plugins.yml carries `github:owner/repo.git` while the registry sees
+        // `github:owner/repo`, and sync()'s drift check uninstalls + reinstalls every run.
+        var repo = parts[1]
+        if repo.hasSuffix(".git") {
+            repo = repo.dropLast(4)
+        }
+        guard validateSegment(repo) else {
+            throw ParseError.invalidFormat(input)
+        }
+        return "github:\(parts[0])/\(repo)"
+    }
+
+    /// Returns `owner/repo` for an https://github.com/ URL, otherwise nil.
+    private static func stripGitHubURL(_ input: String) -> String? {
+        let prefixes = ["https://github.com/", "http://github.com/"]
+        for prefix in prefixes where input.hasPrefix(prefix) {
+            let rest = input.dropFirst(prefix.count)
+            // Drop trailing slash and anything after a second slash (e.g. /tree/main).
+            let parts = rest.split(separator: "/", omittingEmptySubsequences: false)
+            guard parts.count >= 2 else {
+                return nil
+            }
+            return "\(parts[0])/\(parts[1])"
+        }
+        return nil
+    }
+
+    /// Mirrors PluginsManifestEntry.validateOwnerRepo in the app: start alphanumeric,
+    /// then `[A-Za-z0-9._-]`.
+    private static func validateSegment(_ s: Substring) -> Bool {
+        let pattern = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
+        return s.wholeMatch(of: pattern) != nil
     }
 }

--- a/Sources/statusbar-cli/IPC/IPCClient.swift
+++ b/Sources/statusbar-cli/IPC/IPCClient.swift
@@ -58,3 +58,30 @@ enum IPCClientError: Error, CustomStringConvertible {
         }
     }
 }
+
+// MARK: - IPCError + @retroactive CustomStringConvertible
+
+/// Default debug rendering for `IPCError` (defined in the external StatusBarKit package) is
+/// Swift's enum-with-associated-value form — `internalError("...")` — which leaks the case name
+/// to end users. Render it as the underlying message so ArgumentParser's "Error: ..." line is
+/// readable.
+extension IPCError: @retroactive CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .unknownCommand:
+            "Unknown command"
+        case let .widgetNotFound(id):
+            "Widget not found: \(id)"
+        case let .invalidKeyPath(path):
+            "Invalid key path: \(path)"
+        case let .invalidValue(key, reason):
+            "Invalid value for \(key): \(reason)"
+        case let .versionMismatch(server, client):
+            "IPC protocol mismatch (server v\(server), client v\(client)) — reinstall sbar"
+        case let .internalError(message):
+            message
+        @unknown default:
+            "Unknown IPC error"
+        }
+    }
+}

--- a/Tests/StatusBarTests/PluginsInstallCommandHandlerTests.swift
+++ b/Tests/StatusBarTests/PluginsInstallCommandHandlerTests.swift
@@ -1,0 +1,15 @@
+@testable import StatusBar
+import StatusBarKit
+import Testing
+
+@MainActor
+struct PluginsInstallCommandHandlerTests {
+    private let handler = PluginsInstallCommandHandler()
+
+    @Test("Wrong command case throws unknownCommand")
+    func wrongCommandCase() async {
+        await #expect(throws: IPCError.self) {
+            try await handler.handle(.list)
+        }
+    }
+}

--- a/Tests/StatusBarTests/PluginsListCommandHandlerTests.swift
+++ b/Tests/StatusBarTests/PluginsListCommandHandlerTests.swift
@@ -7,8 +7,8 @@ struct PluginsListCommandHandlerTests {
     private let handler = PluginsListCommandHandler()
 
     @Test("List command returns pluginList payload")
-    func returnsPluginList() throws {
-        let payload = try handler.handle(.pluginsList)
+    func returnsPluginList() async throws {
+        let payload = try await handler.handle(.pluginsList)
         guard case .pluginList = payload else {
             Issue.record("Expected .pluginList payload, got \(payload)")
             return
@@ -16,9 +16,9 @@ struct PluginsListCommandHandlerTests {
     }
 
     @Test("Wrong command case throws unknownCommand")
-    func wrongCommandCase() {
-        #expect(throws: IPCError.self) {
-            try handler.handle(.list)
+    func wrongCommandCase() async {
+        await #expect(throws: IPCError.self) {
+            try await handler.handle(.list)
         }
     }
 }

--- a/Tests/StatusBarTests/PluginsManagerTests.swift
+++ b/Tests/StatusBarTests/PluginsManagerTests.swift
@@ -201,24 +201,90 @@ struct PluginsManagerTests {
     // MARK: - remove guards
 
     @Test("remove throws for unknown plugin ID")
-    func removeUnknown() {
+    func removeUnknown() async {
         let env = makeTempEnv()
         defer { env.cleanup() }
         let manager = env.manager
-        #expect(throws: PluginsManagerError.self) {
-            try manager.remove(pluginID: "does-not-exist")
+        await #expect(throws: PluginsManagerError.self) {
+            try await manager.remove(pluginID: "does-not-exist")
         }
     }
 
     @Test("remove rejects local plugins")
-    func removeLocalRejected() throws {
+    func removeLocalRejected() async throws {
         let env = makeTempEnv()
         defer { env.cleanup() }
         let manager = env.manager
         let store = env.store
         try store.add(makeRecord(id: "com.local", githubURL: nil, isLocal: true))
-        #expect(throws: PluginsManagerError.self) {
-            try manager.remove(pluginID: "com.local")
+        await #expect(throws: PluginsManagerError.self) {
+            try await manager.remove(pluginID: "com.local")
+        }
+    }
+
+    @Test("remove(source:) throws unknownSource when nothing matches")
+    func removeBySourceUnknown() async {
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manager = env.manager
+        await #expect(throws: PluginsManagerError.self) {
+            try await manager.remove(source: "github:does/not-exist")
+        }
+    }
+
+    @Test("remove(source:) clears an orphan lock entry case-insensitively")
+    func removeBySourceCaseInsensitiveOrphan() async throws {
+        // Two things in one test:
+        //   1. plugins-lock.yml has mixed-case source `github:Acme/Foo-Widget` while the CLI input
+        //      is lowercase `github:acme/foo-widget` — case-insensitive lookup must match.
+        //   2. pluginStore has no matching record (orphan lock — e.g., plugin failed to load at boot).
+        //      remove(source:) must clean manifest+lock directly without calling installer.uninstall.
+        // After the call, the lock must be empty — that observable side-effect distinguishes a
+        // working case-insensitive path from a silent miss.
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        let manifest = PluginsManifest(plugins: [
+            PluginsManifestEntry(source: "github:Acme/Foo-Widget", version: "1.0.0"),
+        ])
+        let lock = PluginsLock(plugins: [
+            PluginsLockEntry(
+                source: "github:Acme/Foo-Widget",
+                resolvedVersion: "1.0.0",
+                pluginID: "com.acme.foo",
+                bundleName: "FooWidget",
+                assetURL: nil,
+                zipSHA256: nil,
+                resolvedAt: Date()
+            ),
+        ])
+        try env.manifestStore.saveManifest(manifest)
+        try env.manifestStore.saveLock(lock)
+
+        try await env.manager.remove(source: "github:acme/foo-widget")
+
+        #expect(env.manifestStore.currentManifest.plugins.isEmpty)
+        #expect(env.manifestStore.currentLock.plugins.isEmpty)
+    }
+
+    @Test("Concurrent removes queue through the mutation chain instead of racing")
+    func concurrentRemoveSerializes() async throws {
+        // Two unknown-source removes started in parallel must both reach the unknown branch.
+        // If the serializer had the chain bug (second caller doesn't await the first's task),
+        // they'd interleave on currentManifest/currentLock. The observable check is weak — both
+        // throw — but the structural assertion is: the test completes without crash/deadlock,
+        // and a follow-up legitimate remove still works.
+        let env = makeTempEnv()
+        defer { env.cleanup() }
+        async let a: () = {
+            do { try await env.manager.remove(source: "github:a/one") } catch {}
+        }()
+        async let b: () = {
+            do { try await env.manager.remove(source: "github:b/two") } catch {}
+        }()
+        _ = await (a, b)
+        // Mutation chain is still healthy after two queued failures.
+        await #expect(throws: PluginsManagerError.self) {
+            try await env.manager.remove(source: "github:c/three")
         }
     }
 }

--- a/Tests/StatusBarTests/PluginsSyncCommandHandlerTests.swift
+++ b/Tests/StatusBarTests/PluginsSyncCommandHandlerTests.swift
@@ -7,8 +7,8 @@ struct PluginsSyncCommandHandlerTests {
     private let handler = PluginsSyncCommandHandler()
 
     @Test("Sync command returns .ok immediately (work runs detached)")
-    func returnsOk() throws {
-        let payload = try handler.handle(.pluginsSync(frozen: false))
+    func returnsOk() async throws {
+        let payload = try await handler.handle(.pluginsSync(frozen: false))
         guard case .ok = payload else {
             Issue.record("Expected .ok payload, got \(payload)")
             return
@@ -16,9 +16,9 @@ struct PluginsSyncCommandHandlerTests {
     }
 
     @Test("Wrong command case throws unknownCommand")
-    func wrongCommandCase() {
-        #expect(throws: IPCError.self) {
-            try handler.handle(.list)
+    func wrongCommandCase() async {
+        await #expect(throws: IPCError.self) {
+            try await handler.handle(.list)
         }
     }
 }

--- a/Tests/StatusBarTests/PluginsUninstallCommandHandlerTests.swift
+++ b/Tests/StatusBarTests/PluginsUninstallCommandHandlerTests.swift
@@ -1,0 +1,20 @@
+@testable import StatusBar
+import StatusBarKit
+import Testing
+
+@MainActor
+struct PluginsUninstallCommandHandlerTests {
+    private let handler = PluginsUninstallCommandHandler()
+
+    @Test("Wrong command case throws unknownCommand")
+    func wrongCommandCase() async {
+        await #expect(throws: IPCError.self) {
+            try await handler.handle(.list)
+        }
+    }
+
+    // Note: a test for the unknown-source error path would hit PluginsManager.shared and read
+    // the developer's real ~/.config/statusbar/plugins-lock.yml. The unknown-source semantics
+    // are exercised by PluginsManagerTests via the DI'd manifestStore — keeping this suite
+    // singleton-free.
+}

--- a/Tests/StatusBarTests/ToastCommandHandlerTests.swift
+++ b/Tests/StatusBarTests/ToastCommandHandlerTests.swift
@@ -8,9 +8,9 @@ struct ToastCommandHandlerTests {
     private let handler = ToastCommandHandler()
 
     @Test("Valid toast returns toastID")
-    func validToast() throws {
+    func validToast() async throws {
         let request = ToastRequest(title: "Test", level: .info)
-        let payload = try handler.handle(.showToast(request: request))
+        let payload = try await handler.handle(.showToast(request: request))
         guard case let .toastID(id) = payload else {
             Issue.record("Expected .toastID payload")
             return
@@ -19,7 +19,7 @@ struct ToastCommandHandlerTests {
     }
 
     @Test("Toast with all fields returns toastID")
-    func toastWithAllFields() throws {
+    func toastWithAllFields() async throws {
         let request = ToastRequest(
             title: "CPU Warning",
             message: "90% exceeded",
@@ -29,7 +29,7 @@ struct ToastCommandHandlerTests {
             actionLabel: "Open Activity Monitor",
             actionShellCommand: "open -a 'Activity Monitor'"
         )
-        let payload = try handler.handle(.showToast(request: request))
+        let payload = try await handler.handle(.showToast(request: request))
         guard case .toastID = payload else {
             Issue.record("Expected .toastID payload")
             return
@@ -37,9 +37,9 @@ struct ToastCommandHandlerTests {
     }
 
     @Test("Wrong command case throws unknownCommand")
-    func wrongCommandCase() {
-        #expect(throws: IPCError.self) {
-            try handler.handle(.list)
+    func wrongCommandCase() async {
+        await #expect(throws: IPCError.self) {
+            try await handler.handle(.list)
         }
     }
 }

--- a/Tests/StatusBarTests/TriggerCommandHandlerTests.swift
+++ b/Tests/StatusBarTests/TriggerCommandHandlerTests.swift
@@ -8,30 +8,30 @@ struct TriggerCommandHandlerTests {
     private let handler = TriggerCommandHandler()
 
     @Test("Valid trigger returns .ok")
-    func validTrigger() throws {
-        let payload = try handler.handle(.trigger(event: "com.example.myapp.ping", payload: nil))
+    func validTrigger() async throws {
+        let payload = try await handler.handle(.trigger(event: "com.example.myapp.ping", payload: nil))
         #expect(payload == .ok)
     }
 
     @Test("Trigger with payload returns .ok")
-    func triggerWithPayload() throws {
-        let payload = try handler.handle(
+    func triggerWithPayload() async throws {
+        let payload = try await handler.handle(
             .trigger(event: "com.example.myapp.deploy", payload: .object(["repo": .string("main")]))
         )
         #expect(payload == .ok)
     }
 
     @Test("Empty event name throws invalidValue")
-    func emptyEventName() {
-        #expect(throws: IPCError.self) {
-            try handler.handle(.trigger(event: "", payload: nil))
+    func emptyEventName() async {
+        await #expect(throws: IPCError.self) {
+            try await handler.handle(.trigger(event: "", payload: nil))
         }
     }
 
     @Test("Wrong command case throws unknownCommand")
-    func wrongCommandCase() {
-        #expect(throws: IPCError.self) {
-            try handler.handle(.list)
+    func wrongCommandCase() async {
+        await #expect(throws: IPCError.self) {
+            try await handler.handle(.list)
         }
     }
 }

--- a/Tests/statusbar-cliTests/PluginSourceParserTests.swift
+++ b/Tests/statusbar-cliTests/PluginSourceParserTests.swift
@@ -1,0 +1,81 @@
+@testable import sbar
+import Testing
+
+struct PluginSourceParserTests {
+    @Test
+    func `owner-slash-repo is normalized to github prefix`() throws {
+        #expect(try PluginSourceParser.normalize("acme/foo-widget") == "github:acme/foo-widget")
+    }
+
+    @Test
+    func `github prefix passes through unchanged`() throws {
+        #expect(try PluginSourceParser.normalize("github:acme/foo-widget") == "github:acme/foo-widget")
+    }
+
+    @Test
+    func `https URL is normalized`() throws {
+        #expect(try PluginSourceParser.normalize("https://github.com/acme/foo-widget") == "github:acme/foo-widget")
+    }
+
+    @Test
+    func `https URL with extra path segments is normalized to owner-repo`() throws {
+        // `gh repo view <url>` style URLs sometimes include /tree/main — accept and ignore the tail.
+        #expect(
+            try PluginSourceParser.normalize("https://github.com/acme/foo-widget/tree/main") == "github:acme/foo-widget"
+        )
+    }
+
+    @Test
+    func `whitespace is trimmed before parsing`() throws {
+        #expect(try PluginSourceParser.normalize("  acme/foo-widget  ") == "github:acme/foo-widget")
+    }
+
+    @Test
+    func `empty input throws`() {
+        #expect(throws: PluginSourceParser.ParseError.self) {
+            try PluginSourceParser.normalize("")
+        }
+    }
+
+    @Test
+    func `missing slash throws`() {
+        #expect(throws: PluginSourceParser.ParseError.self) {
+            try PluginSourceParser.normalize("acme")
+        }
+    }
+
+    @Test
+    func `leading dot in owner is rejected as path traversal`() {
+        // Mirrors the app-side regex that excludes `.` and `..` to keep plugins.yml from pointing
+        // at parent directories or non-repo paths.
+        #expect(throws: PluginSourceParser.ParseError.self) {
+            try PluginSourceParser.normalize(".acme/foo")
+        }
+    }
+
+    @Test
+    func `empty repo segment is rejected`() {
+        #expect(throws: PluginSourceParser.ParseError.self) {
+            try PluginSourceParser.normalize("acme/")
+        }
+    }
+
+    @Test
+    func `dots and dashes inside segments are accepted`() throws {
+        #expect(try PluginSourceParser.normalize("a-co/foo.bar_baz-2") == "github:a-co/foo.bar_baz-2")
+    }
+
+    @Test
+    func `clone URL .git suffix is stripped to match the registry record`() throws {
+        // Without stripping, sync()'s drift check sees `github:acme/foo` on the registry vs
+        // `github:acme/foo.git` in the manifest and uninstalls+reinstalls every run.
+        #expect(try PluginSourceParser.normalize("https://github.com/acme/foo.git") == "github:acme/foo")
+        #expect(try PluginSourceParser.normalize("acme/foo.git") == "github:acme/foo")
+        #expect(try PluginSourceParser.normalize("github:acme/foo.git") == "github:acme/foo")
+    }
+
+    @Test
+    func `http URL is also accepted`() throws {
+        #expect(try PluginSourceParser.normalize("http://github.com/acme/foo") == "github:acme/foo")
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new sbar subcommands so users can install and remove plugins from the terminal without opening Preferences:

```
sbar plugins install <source> [--version <tag>] [--json]
sbar plugins uninstall <source>
```

`<source>` accepts `owner/repo`, `github:owner/repo`, and `https://github.com/owner/repo` (with or without a trailing `.git`).

## Changes

- **CLI**: new `install` / `uninstall` subcommands under `sbar plugins`, plus a `PluginSourceParser` that canonicalizes the three accepted input forms (and strips `.git` clone-URL suffixes so the source string matches what the app stores on the registry record).
- **IPC**: two new handlers wired up to the `pluginsInstall` / `pluginsUninstall` cases added in StatusBarKit 1.10.0. The `CommandHandling` protocol becomes `async throws` so handlers can await network work without blocking the dispatcher; existing handlers keep their bodies and just gain `async` on the signature.
- **PluginsManager**: `add` now returns an `AddResult` (record + action), so the install handler can skip a hot-reload when nothing on disk changed. `remove(pluginID:)` / `remove(source:)` become `async` and run through a shared `mutationTail` task chain — together with `sync()` — so concurrent CLI installs / uninstalls / syncs serialize against each other.
- **Correctness fixes uncovered along the way**:
  - All source comparisons are case-insensitive (manifest lookup, removal, lock matching), matching the existing drift-detection convention. Without this, `sbar plugins uninstall acme/foo` would leave a `github:Acme/Foo` entry behind in plugins.yml.
  - `sbar plugins install <source>` without `--version` preserves an existing pin in plugins.yml instead of overwriting it with `latest`.
  - `remove(source:)` can clean orphan lock entries (lock has an entry but the registry record is missing), so users aren't stuck after a failed boot-time load.
  - `IPCServer` clears `SO_SNDTIMEO` after reading the request so a slow install's response write isn't bounded by the 5s accept-time timeout.
- **Tests**: source parser unit tests, handler wrong-command-case tests, a concurrency-chain smoke test, and a case-insensitive orphan-cleanup test that asserts observable lock state (the prior tautological version passed regardless of whether case-insensitive matching worked).

## Notes

- Depends on StatusBarKit 1.10.0 (bumped in the first commit).
- Existing handler tests were converted to `async`; no behavior changes there.
- One known limitation: when hot-load fails after a successful disk install (e.g., StatusBarKit version mismatch), the CLI still prints "Installed X" with exit code 0 — the toast notes a restart is required, but the IPC payload has no field to surface that to scripts. Fixing requires adding a field to `InstalledPluginDTO` in StatusBarKit and is left for a follow-up.
- Not yet exercised end-to-end against a real plugin install — local manual smoke test recommended before merge.

## Test plan

- [ ] `swift test` passes (269 tests in 37 suites)
- [ ] `make run-dev` then `sbar plugins install <owner>/<repo>` against a real plugin
- [ ] `sbar plugins install <owner>/<repo> --json` returns a sensible InstalledPluginDTO with iso8601 `installedAt`
- [ ] `sbar plugins uninstall <owner>/<repo>` removes the plugin and clears manifest + lock entries
- [ ] Idempotent re-install (`sbar plugins install foo/bar` twice) does not tear down live widgets the second time
- [ ] `sbar plugins install Acme/Foo` followed by `sbar plugins uninstall acme/foo` cleans plugins.yml fully (case-insensitive path)